### PR TITLE
feat: ship shared validation runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.1.0b12 - 2026-03-29
+
+### Added
+
+- Internal shipped validation helpers under `ml4t.backtest._validation`, including:
+  - `lean_runner.py` for shared LEAN CLI orchestration, data export, and artifact parsing
+  - `vectorbt_runner.py` for shared VectorBT matrix prep, execution, and result extraction
+  - `backtrader_runner.py` for shared Backtrader target-share execution and PyFolio parsing
+  - `zipline_runner.py` for shared Zipline bundle orchestration and transaction parsing
+
+### Changed
+
+- The library validation harness now uses the shared `_validation` helpers instead of
+  carrying duplicate LEAN, VectorBT, Backtrader, and Zipline integration logic inside
+  `validation/benchmark_suite.py`.
+- Chapter 16 book parity code can now rely on the released `ml4t-backtest` package for
+  shared cross-engine validation machinery instead of vendoring those heavy helpers.
+
+### Validation
+
+- `uv run pytest tests/benchmark/test_lean_adapter.py tests/benchmark/test_backtrader_zipline_runners.py tests/test_config_wiring.py -q`
+- `uv run python -m py_compile src/ml4t/backtest/_validation/lean_runner.py src/ml4t/backtest/_validation/vectorbt_runner.py src/ml4t/backtest/_validation/backtrader_runner.py src/ml4t/backtest/_validation/zipline_runner.py validation/benchmark_suite.py`
+
 ## 0.1.0b11 - 2026-03-24
 
 ### Added

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -13,7 +13,6 @@ Understanding these helps set realistic expectations for backtest results.
 
 ### Settlement Delay (Optional)
 - `settlement_delay` models T+N settlement (proceeds unavailable for N bars)
-- Used by the `lean_strict` profile (T+2 for US equities)
 - Does not model partial settlement or settlement failure
 
 ## Corporate Actions
@@ -187,7 +186,7 @@ and 1500-bar stress tests across 9 market regimes.
 | zipline_strict | 225,583 | 0 trades (0.00%) | $19 (0.0001%) |
 | backtrader_strict | 216,980 | 1 trade (0.0005%) | $503 (0.004%) |
 | vectorbt_strict | 210,352 | 91 trades (0.04%) | $0 (0.00%) |
-| lean_strict | 226,172 | 589 trades (0.26%) | $7,200 (0.66%) |
+| lean | 428,459 fills | 0 fills (0.00%) | $1.55 (0.0002%) |
 
 ### What's Validated
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Large-scale validation (250 assets x 20 years, real data):
 | zipline_strict | 225,583 | match | 0 trades, $19 (0.0001%) |
 | backtrader_strict | 216,980 | match | 1 trade (0.0005%) |
 | vectorbt_strict | 210,352 | match | 91 trades (0.04%) |
-| lean_strict | 226,172 | match | 589 trades (0.26%) |
+| lean | 428,459 fills | match | 0 fills, $1.55 (0.0002%) |
 
 See [validation/README.md](validation/README.md) for methodology and detailed results.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ result = run_backtest(prices, BuyAndHold(), config="backtrader")
 | `zipline_strict` | 225,583 | 0 (0.00%) | $19 (0.0001%) |
 | `backtrader_strict` | 216,980 | 1 (0.0005%) | $503 (0.004%) |
 | `vectorbt_strict` | 210,352 | 91 (0.04%) | $0 (0.00%) |
-| `lean_strict` | 226,172 | 589 (0.26%) | $7.2K (0.66%) |
+| `lean` | 428,459 fills | 0 (0.00%) | $1.55 (0.0002%) |
 
 ## Installation
 

--- a/docs/user-guide/accounts.md
+++ b/docs/user-guide/accounts.md
@@ -186,7 +186,7 @@ config = BacktestConfig.from_preset("realistic")
 ```
 
 Each preset sets all 40+ behavioral knobs to match the target framework's behavior.
-Strict variants (`backtrader_strict`, `vectorbt_strict`, `zipline_strict`, `lean_strict`)
+Strict variants (`backtrader_strict`, `vectorbt_strict`, `zipline_strict`)
 are also available for exact parity testing.
 
 ## Insufficient Funds

--- a/docs/user-guide/profiles.md
+++ b/docs/user-guide/profiles.md
@@ -25,7 +25,6 @@ Strict variants tune additional knobs (cash validation, settlement, short polici
 | `backtrader_strict` | backtrader | Submission precheck, simple cash check |
 | `vectorbt_strict` | vectorbt | Lock notional for shorts, FIFO ordering |
 | `zipline_strict` | zipline | Skip cash validation, allow shorts |
-| `lean_strict` | lean | Buying power reservation, T+2 settlement |
 
 ### Aliases
 
@@ -112,7 +111,7 @@ Each profile has been validated at two levels:
 | `zipline_strict` | 225,583 | 0 (0.00%) | $19 (0.0001%) |
 | `backtrader_strict` | 216,980 | 1 (0.0005%) | $503 (0.004%) |
 | `vectorbt_strict` | 210,352 | 91 (0.04%) | $0 (0.00%) |
-| `lean_strict` | 226,172 | 589 (0.26%) | $7.2K (0.66%) |
+| `lean` | 428,459 fills | 0 (0.00%) | $1.55 (0.0002%) |
 
 ## Performance
 

--- a/src/ml4t/backtest/_validation/__init__.py
+++ b/src/ml4t/backtest/_validation/__init__.py
@@ -1,0 +1,1 @@
+"""Internal validation helpers not exposed as part of the public API."""

--- a/src/ml4t/backtest/_validation/backtrader_runner.py
+++ b/src/ml4t/backtest/_validation/backtrader_runner.py
@@ -1,0 +1,153 @@
+"""Shared Backtrader helpers for internal validation workflows."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass
+class BacktraderRunResult:
+    """Standardized Backtrader run artifacts for benchmark consumers."""
+
+    final_value: float
+    num_trades: int
+    trades_df: pd.DataFrame | None
+    positions_df: pd.DataFrame | None
+    transactions_df: pd.DataFrame | None
+
+
+def load_backtrader_package() -> Any:
+    """Import and return the Backtrader package."""
+    return importlib.import_module("backtrader")
+
+
+def transactions_to_trade_log(transactions: pd.DataFrame) -> pd.DataFrame | None:
+    """Convert PyFolio transactions into completed round-trip trades."""
+    if len(transactions) == 0 or "symbol" not in transactions.columns:
+        return None
+
+    trade_records: list[dict[str, object]] = []
+    for symbol in transactions["symbol"].unique():
+        symbol_txns = transactions[transactions["symbol"] == symbol].sort_index()
+
+        running_pos = 0.0
+        entry_time = None
+        entry_price = None
+        entry_size = 0.0
+
+        for dt, row in symbol_txns.iterrows():
+            amount = float(row["amount"])
+            price = float(row["price"])
+            prev_pos = running_pos
+            running_pos += amount
+
+            if prev_pos == 0 and running_pos != 0:
+                entry_time = dt
+                entry_price = price
+                entry_size = amount
+            elif prev_pos != 0 and running_pos == 0:
+                assert entry_time is not None
+                assert entry_price is not None
+                pnl = (price - entry_price) * entry_size
+                trade_records.append(
+                    {
+                        "entry_date": entry_time,
+                        "exit_date": dt,
+                        "asset": str(symbol),
+                        "side": "long" if entry_size > 0 else "short",
+                        "quantity": abs(entry_size),
+                        "entry_price": entry_price,
+                        "exit_price": price,
+                        "pnl": pnl,
+                    }
+                )
+                entry_time = None
+                entry_price = None
+            elif prev_pos != 0 and running_pos != 0 and (prev_pos > 0) != (running_pos > 0):
+                assert entry_time is not None
+                assert entry_price is not None
+                pnl = (price - entry_price) * entry_size
+                trade_records.append(
+                    {
+                        "entry_date": entry_time,
+                        "exit_date": dt,
+                        "asset": str(symbol),
+                        "side": "long" if entry_size > 0 else "short",
+                        "quantity": abs(entry_size),
+                        "entry_price": entry_price,
+                        "exit_price": price,
+                        "pnl": pnl,
+                    }
+                )
+                entry_time = dt
+                entry_price = price
+                entry_size = running_pos
+
+    if not trade_records:
+        return None
+    return pd.DataFrame(trade_records).sort_values("entry_date").reset_index(drop=True)
+
+
+def run_backtrader_target_shares(
+    *,
+    bt: Any,
+    price_data: dict[str, pd.DataFrame],
+    target_lookup: dict[str, dict[str, float]],
+    initial_cash: float,
+    commission_pct: float,
+) -> BacktraderRunResult:
+    """Run a canonical target-share strategy through Backtrader."""
+
+    class TopBottomBTStrategy(bt.Strategy):
+        def __init__(self):
+            self.target_lookup = target_lookup
+            self.data_by_name = {data._name: data for data in self.datas}
+
+        def next(self):
+            dt = self.datas[0].datetime.datetime(0)
+            dt_key = dt.strftime("%Y-%m-%d")
+            targets = self.target_lookup.get(dt_key, {})
+
+            active_names = set(targets.keys())
+            for data in self.datas:
+                if self.getposition(data).size != 0:
+                    active_names.add(data._name)
+
+            for asset_name in sorted(active_names):
+                data = self.data_by_name[asset_name]
+                current_size = self.getposition(data).size
+                target_size = targets.get(asset_name, 0.0)
+                if current_size != target_size:
+                    self.order_target_size(data=data, target=target_size)
+
+    cerebro = bt.Cerebro()
+    cerebro.addstrategy(TopBottomBTStrategy)
+
+    for asset_name, df in price_data.items():
+        data = bt.feeds.PandasData(dataname=df, name=asset_name)
+        cerebro.adddata(data)
+
+    cerebro.broker.setcash(initial_cash)
+    if commission_pct > 0:
+        cerebro.broker.setcommission(commission=commission_pct)
+    cerebro.addanalyzer(bt.analyzers.PyFolio, _name="pyfolio")
+
+    results = cerebro.run()
+    strat = results[0]
+    pyfolio_analyzer = strat.analyzers.getbyname("pyfolio")
+    _returns, positions, transactions, _gross_lev = pyfolio_analyzer.get_pf_items()
+
+    trades_df = transactions_to_trade_log(transactions)
+    num_trades = len(trades_df) if trades_df is not None else 0
+
+    return BacktraderRunResult(
+        final_value=float(cerebro.broker.getvalue()),
+        num_trades=num_trades,
+        trades_df=trades_df,
+        positions_df=positions,
+        transactions_df=transactions,
+    )

--- a/src/ml4t/backtest/_validation/lean_runner.py
+++ b/src/ml4t/backtest/_validation/lean_runner.py
@@ -1,0 +1,346 @@
+"""Shared LEAN orchestration helpers for internal validation workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import time
+import zipfile
+from collections.abc import Mapping
+from pathlib import Path
+
+import pandas as pd
+
+
+def parse_lean_int(value: object) -> int:
+    """Parse an integer-like value from LEAN summary text."""
+    if value is None:
+        return 0
+    text = str(value).replace(",", "").strip()
+    if not text:
+        return 0
+    token = text.split()[0]
+    try:
+        return int(float(token))
+    except ValueError:
+        return 0
+
+
+def parse_lean_float(value: object) -> float:
+    """Parse a float-like value from LEAN summary text."""
+    if value is None:
+        return 0.0
+    text = str(value).replace(",", "").replace("$", "").replace("%", "").strip()
+    if not text:
+        return 0.0
+    token = text.split()[0]
+    try:
+        return float(token)
+    except ValueError:
+        return 0.0
+
+
+def encode_sequential_ticker(idx: int) -> str:
+    """Create a deterministic short ticker namespace from an integer index."""
+    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    value = idx
+    chars: list[str] = []
+    for _ in range(4):
+        chars.append(letters[value % 26])
+        value //= 26
+    return "".join(reversed(chars))
+
+
+def encode_hashed_ticker(project_slug: str, asset_name: str, attempt: int = 0) -> str:
+    """Create a project-scoped hashed ticker namespace."""
+    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    digest = hashlib.sha1(f"{project_slug}|{asset_name}|{attempt}".encode()).digest()
+    value = int.from_bytes(digest[:8], "big")
+    chars: list[str] = []
+    for _ in range(6):
+        chars.append(letters[value % 26])
+        value //= 26
+    return "".join(reversed(chars))
+
+
+def build_sequential_ticker_map(asset_names: list[str]) -> dict[str, str]:
+    """Map asset names to stable short tickers in sorted asset order."""
+    return {asset_name: encode_sequential_ticker(i) for i, asset_name in enumerate(asset_names)}
+
+
+def build_hashed_ticker_map(project_slug: str, asset_names: list[str]) -> dict[str, str]:
+    """Map asset names to unique project-scoped hashed tickers."""
+    asset_to_ticker: dict[str, str] = {}
+    used: set[str] = set()
+    for asset_name in asset_names:
+        attempt = 0
+        while True:
+            ticker = encode_hashed_ticker(project_slug, asset_name, attempt)
+            if ticker not in used:
+                asset_to_ticker[asset_name] = ticker
+                used.add(ticker)
+                break
+            attempt += 1
+    return asset_to_ticker
+
+
+def read_lean_csv(path: Path, parse_dates: list[str] | None = None) -> pd.DataFrame | None:
+    """Read a LEAN CSV artifact if it exists and is non-empty."""
+    if not path.exists() or path.stat().st_size == 0:
+        return None
+    df = pd.read_csv(path, parse_dates=parse_dates or [], low_memory=False)
+    return df if not df.empty else None
+
+
+def load_lean_symbol_map(output_dir: Path) -> dict[str, str]:
+    """Load a decoded LEAN symbol map from an output directory."""
+    symbol_map_path = output_dir / "ml4t_symbol_map.json"
+    if not symbol_map_path.exists():
+        return {}
+    try:
+        data = json.loads(symbol_map_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(symbol): str(asset) for symbol, asset in data.items()}
+
+
+def load_lean_artifacts(
+    output_dir: Path,
+) -> tuple[int, float, pd.DataFrame | None, pd.DataFrame | None, pd.DataFrame | None]:
+    """Load standard LEAN summary, equity, and order-event artifacts."""
+    summary_files = sorted(output_dir.glob("*-summary.json"))
+    if not summary_files:
+        raise FileNotFoundError(f"LEAN summary file not found in {output_dir}")
+
+    summary = json.loads(summary_files[-1].read_text(encoding="utf-8"))
+    trade_stats = summary.get("totalPerformance", {}).get("tradeStatistics", {})
+    stats = summary.get("statistics", {})
+    portfolio_stats = summary.get("totalPerformance", {}).get("portfolioStatistics", {})
+    state = summary.get("state", {})
+
+    num_trades = parse_lean_int(trade_stats.get("totalNumberOfTrades"))
+    if num_trades == 0:
+        num_trades = parse_lean_int(state.get("OrderCount"))
+    if num_trades == 0:
+        num_trades = parse_lean_int(stats.get("Total Orders"))
+
+    final_value = parse_lean_float(portfolio_stats.get("endEquity"))
+    if final_value == 0.0:
+        final_value = parse_lean_float(stats.get("End Equity"))
+
+    symbol_map = load_lean_symbol_map(output_dir)
+    order_events_df = read_lean_csv(output_dir / "ml4t_order_events.csv", parse_dates=["timestamp"])
+    equity_df = read_lean_csv(output_dir / "ml4t_daily_equity.csv", parse_dates=["timestamp"])
+
+    if final_value == 0.0 and equity_df is not None and "equity" in equity_df.columns:
+        final_value = float(equity_df.iloc[-1]["equity"])
+
+    trades_df = None
+    if order_events_df is not None:
+        order_events_df = order_events_df.sort_values("timestamp").reset_index(drop=True)
+        if "symbol" in order_events_df.columns:
+            symbols = order_events_df["symbol"].astype(str)
+            order_events_df["asset"] = symbols.map(symbol_map).fillna(symbols)
+        if "status" in order_events_df.columns:
+            status_series = order_events_df["status"].astype(str).str.lower()
+            fill_mask = status_series.isin({"filled", "partiallyfilled", "partially_filled"})
+        else:
+            fill_mask = pd.Series(True, index=order_events_df.index)
+
+        fills_df = order_events_df.loc[fill_mask].copy()
+        if not fills_df.empty:
+            if "fill_quantity" in fills_df.columns:
+                fills_df["quantity"] = fills_df["fill_quantity"].abs()
+            if "direction" in fills_df.columns:
+                fills_df["side"] = fills_df["direction"].astype(str).str.lower()
+            if "asset" in fills_df.columns:
+                fills_df["asset"] = fills_df["asset"].astype(str)
+            elif "symbol" in fills_df.columns:
+                fills_df["asset"] = fills_df["symbol"].astype(str)
+
+            keep_cols = [
+                "timestamp",
+                "asset",
+                "side",
+                "quantity",
+                "fill_price",
+                "fee",
+                "status",
+                "order_id",
+                "message",
+            ]
+            available_cols = [col for col in keep_cols if col in fills_df.columns]
+            trades_df = fills_df[available_cols].reset_index(drop=True)
+            if num_trades == 0:
+                num_trades = int(len(trades_df))
+
+    return num_trades, final_value, trades_df, equity_df, order_events_df
+
+
+def resolve_lean_command() -> list[str]:
+    """Resolve the local LEAN CLI command."""
+    lean_binary = shutil.which("lean")
+    if lean_binary is not None:
+        return [lean_binary]
+
+    uvx_binary = shutil.which("uvx")
+    if uvx_binary is None:
+        raise FileNotFoundError("Neither 'lean' nor 'uvx' executable found.")
+    return [uvx_binary, "--python", "3.12", "--with", "setuptools<81", "lean"]
+
+
+def make_lean_env() -> dict[str, str]:
+    """Build the subprocess environment for local LEAN runs."""
+    env = os.environ.copy()
+    env.setdefault("UV_CACHE_DIR", "/tmp/uv-cache")
+    env.setdefault("UV_TOOL_DIR", "/tmp/uv-tools")
+    return env
+
+
+def check_lean_cli(lean_cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
+    """Return the local LEAN version string or raise on failure."""
+    result = subprocess.run(
+        lean_cmd + ["--version"],
+        cwd=str(cwd),
+        env=env or make_lean_env(),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_text = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"LEAN CLI unavailable: {error_text}")
+    return (result.stdout or result.stderr).strip()
+
+
+def export_lean_daily_data(
+    *,
+    data_root: Path,
+    prices_by_asset: Mapping[str, pd.DataFrame],
+    asset_to_ticker: Mapping[str, str],
+    manifest_path: Path,
+    signature_payload: dict[str, object],
+) -> bool:
+    """Export daily OHLCV data to LEAN zip format with manifest caching."""
+    (data_root / "map_files").mkdir(parents=True, exist_ok=True)
+    (data_root / "factor_files").mkdir(parents=True, exist_ok=True)
+    (data_root / "daily").mkdir(parents=True, exist_ok=True)
+
+    signature = hashlib.md5(json.dumps(signature_payload, sort_keys=True).encode()).hexdigest()
+    cache_hit = False
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            manifest = {}
+        cache_hit = manifest.get("signature") == signature
+        if cache_hit:
+            expected_files = [
+                data_root / "daily" / f"{ticker.lower()}.zip" for ticker in asset_to_ticker.values()
+            ]
+            cache_hit = all(path.exists() for path in expected_files)
+
+    if cache_hit:
+        return True
+
+    for asset_name, asset_df in prices_by_asset.items():
+        ticker = asset_to_ticker[asset_name]
+        ticker_lower = ticker.lower()
+        asset_df = asset_df.sort_index()
+        if asset_df.empty:
+            continue
+
+        lines: list[str] = []
+        for ts, row in asset_df.iterrows():
+            dt = pd.Timestamp(ts)
+            dt = dt.tz_convert(None) if dt.tz is not None else dt
+            open_px = int(round(float(row["open"]) * 10000.0))
+            high_px = int(round(float(row["high"]) * 10000.0))
+            low_px = int(round(float(row["low"]) * 10000.0))
+            close_px = int(round(float(row["close"]) * 10000.0))
+            volume = max(1, int(round(float(row["volume"]))))
+            lines.append(
+                f"{dt.strftime('%Y%m%d')} 00:00,"
+                f"{open_px},{max(open_px, high_px, low_px, close_px)},"
+                f"{min(open_px, high_px, low_px, close_px)},{close_px},{volume}"
+            )
+
+        with zipfile.ZipFile(
+            data_root / "daily" / f"{ticker_lower}.zip",
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+        ) as zf:
+            zf.writestr(f"{ticker_lower}.csv", "\n".join(lines))
+
+        first_dt = pd.Timestamp(asset_df.index[0])
+        first_dt = first_dt.tz_convert(None) if first_dt.tz is not None else first_dt
+        first_key = first_dt.strftime("%Y%m%d")
+        (data_root / "map_files" / f"{ticker_lower}.csv").write_text(
+            f"{first_key},{ticker_lower}\n20501231,{ticker_lower}\n",
+            encoding="utf-8",
+        )
+        (data_root / "factor_files" / f"{ticker_lower}.csv").write_text(
+            f"{first_key},1,1,1\n20501231,1,1,0\n",
+            encoding="utf-8",
+        )
+
+    manifest_path.write_text(
+        json.dumps({"signature": signature, "payload": signature_payload}, indent=2),
+        encoding="utf-8",
+    )
+    return False
+
+
+def run_lean_backtest(
+    *,
+    lean_cmd: list[str],
+    cwd: Path,
+    project_dir: Path,
+    lean_config: Path,
+    output_dir: Path,
+    timeout: int = 1800,
+    env: dict[str, str] | None = None,
+) -> float:
+    """Run a LEAN backtest and return the runtime in seconds."""
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+
+    run_cmd = lean_cmd + [
+        "backtest",
+        str(project_dir),
+        "--lean-config",
+        str(lean_config),
+        "--no-update",
+        "--output",
+        str(output_dir),
+    ]
+    start_time = time.perf_counter()
+    result = subprocess.run(
+        run_cmd,
+        cwd=str(cwd),
+        env=env or make_lean_env(),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    runtime_sec = time.perf_counter() - start_time
+    if result.returncode != 0:
+        error_text = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"LEAN backtest failed: {error_text}")
+    return runtime_sec
+
+
+def copy_lean_artifacts(project_dir: Path, output_dir: Path, artifact_names: list[str]) -> None:
+    """Copy locally-emitted LEAN artifacts from project to output directory."""
+    for artifact_name in artifact_names:
+        src = project_dir / artifact_name
+        dst = output_dir / artifact_name
+        if src.exists():
+            shutil.copy2(src, dst)

--- a/src/ml4t/backtest/_validation/vectorbt_runner.py
+++ b/src/ml4t/backtest/_validation/vectorbt_runner.py
@@ -1,0 +1,163 @@
+"""Shared VectorBT helpers for internal validation workflows."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping
+from typing import Any
+
+import pandas as pd
+import polars as pl
+
+
+def load_vectorbt_package(package_name: str = "vectorbt") -> Any:
+    """Import and return a VectorBT package."""
+    return importlib.import_module(package_name)
+
+
+def prices_to_wide(prices: pl.DataFrame, value_col: str = "close") -> pd.DataFrame:
+    """Convert long-format Polars prices to a wide pandas price matrix."""
+    wide = (
+        prices.select("timestamp", "symbol", value_col)
+        .pivot(on="symbol", index="timestamp", values=value_col)
+        .sort("timestamp")
+        .to_pandas()
+        .set_index("timestamp")
+    )
+    wide.index = pd.DatetimeIndex(wide.index)
+    return wide
+
+
+def align_weights_to_prices(
+    weights: pd.DataFrame, close: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Align target weights to a price matrix."""
+    common_assets = [column for column in close.columns if column in weights.columns]
+    close = close[common_assets]
+    weights_aligned = weights[common_assets].reindex(close.index)
+    return close, weights_aligned
+
+
+def run_vectorbt_orders(
+    *,
+    vbt: Any,
+    close: pd.DataFrame,
+    size: pd.DataFrame,
+    size_type: str,
+    init_cash: float,
+    fees: float,
+    slippage: float = 0.0,
+    cash_sharing: bool = True,
+    group_by: bool | None = None,
+    lock_cash: bool | None = None,
+):
+    """Run `Portfolio.from_orders` with consistent defaults across harnesses."""
+    kwargs: dict[str, object] = {
+        "close": close,
+        "size": size,
+        "size_type": size_type,
+        "init_cash": init_cash,
+        "fees": fees,
+        "slippage": slippage,
+        "cash_sharing": cash_sharing,
+    }
+    if group_by is not None:
+        kwargs["group_by"] = group_by
+    if lock_cash is not None:
+        kwargs["lock_cash"] = lock_cash
+    return vbt.Portfolio.from_orders(**kwargs)
+
+
+def get_equity_curve(portfolio: Any) -> pd.Series:
+    """Extract a one-dimensional portfolio value series."""
+    value_attr = portfolio.value
+    equity = value_attr() if callable(value_attr) else value_attr
+    if isinstance(equity, pd.DataFrame):
+        equity = equity.iloc[:, 0] if equity.shape[1] == 1 else equity.sum(axis=1)
+    equity = pd.Series(equity)
+    equity.index = pd.DatetimeIndex(equity.index)
+    equity.name = "portfolio_value"
+    return equity
+
+
+def extract_order_log(portfolio: Any) -> pd.DataFrame:
+    """Extract standardized order records from a VectorBT portfolio."""
+    orders = portfolio.orders.records_readable
+    rows: list[dict[str, object]] = []
+    if len(orders) > 0:
+        for _, row in orders.iterrows():
+            rows.append(
+                {
+                    "timestamp": row.get("Timestamp"),
+                    "symbol": row.get("Column"),
+                    "side": "buy" if row.get("Side") == "Buy" else "sell",
+                    "quantity": float(row.get("Size", 0.0)),
+                    "price": float(row.get("Price", 0.0)),
+                    "commission": float(row.get("Fees", 0.0)),
+                }
+            )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=["timestamp", "symbol", "side", "quantity", "price", "commission"]
+        )
+    return pd.DataFrame(rows)
+
+
+def extract_trade_log(portfolio: Any) -> pd.DataFrame:
+    """Extract standardized round-trip trade records from a VectorBT portfolio."""
+    trades_readable = portfolio.trades.records_readable
+    if len(trades_readable) == 0:
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "asset",
+                "side",
+                "quantity",
+                "entry_price",
+                "exit_price",
+                "pnl",
+            ]
+        )
+
+    entry_col = "Entry Timestamp" if "Entry Timestamp" in trades_readable.columns else "Entry Index"
+    trades_readable = trades_readable.sort_values(entry_col)
+    rows: list[dict[str, object]] = []
+    for _, row in trades_readable.iterrows():
+        direction = str(row.get("Direction", "Long")).lower()
+        rows.append(
+            {
+                "timestamp": row.get("Entry Timestamp", row.get("Entry Index")),
+                "asset": row.get("Column", "unknown"),
+                "side": "long" if direction == "long" else "short",
+                "quantity": abs(float(row.get("Size", 0.0))),
+                "entry_price": float(row.get("Avg Entry Price", row.get("Entry Price", 0.0))),
+                "exit_price": float(row.get("Avg Exit Price", row.get("Exit Price", 0.0))),
+                "pnl": float(row.get("PnL", 0.0)),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def summarize_order_run(
+    equity: pd.Series, orders_df: pd.DataFrame, initial_cash: float
+) -> Mapping[str, float]:
+    """Compute lightweight summary metrics for order-based VectorBT runs."""
+    total_return = float(equity.iloc[-1] / initial_cash - 1.0)
+    daily_returns = equity.pct_change().dropna()
+    sharpe = 0.0
+    if len(daily_returns) > 1 and daily_returns.std() > 0:
+        sharpe = float(daily_returns.mean() / daily_returns.std() * (252**0.5))
+
+    cummax = equity.cummax()
+    drawdown = (equity - cummax) / cummax
+    total_commission = float(orders_df["commission"].sum()) if len(orders_df) > 0 else 0.0
+    return {
+        "initial_cash": initial_cash,
+        "final_value": float(equity.iloc[-1]),
+        "total_return": total_return,
+        "sharpe": sharpe,
+        "max_drawdown": float(drawdown.min()) if len(drawdown) > 0 else 0.0,
+        "num_trades": int(len(orders_df)),
+        "total_commission": total_commission,
+    }

--- a/src/ml4t/backtest/_validation/zipline_runner.py
+++ b/src/ml4t/backtest/_validation/zipline_runner.py
@@ -100,7 +100,11 @@ def transactions_to_trade_log(transactions: pd.DataFrame) -> pd.DataFrame | None
         if "asset" in transactions.columns
         else None
     )
-    if symbol_col is None or amount_col not in transactions.columns or price_col not in transactions.columns:
+    if (
+        symbol_col is None
+        or amount_col not in transactions.columns
+        or price_col not in transactions.columns
+    ):
         return None
 
     trade_records: list[dict[str, object]] = []
@@ -361,7 +365,9 @@ def run_zipline_target_shares(
     transactions = flatten_result_column(results, "transactions")
     orders = flatten_result_column(results, "orders")
     trades_df = transactions_to_trade_log(transactions)
-    num_trades = len(trades_df) if trades_df is not None else int(len(orders)) if not orders.empty else 0
+    num_trades = (
+        len(trades_df) if trades_df is not None else int(len(orders)) if not orders.empty else 0
+    )
 
     return ZiplineRunResult(
         final_value=float(results["portfolio_value"].iloc[-1]),

--- a/src/ml4t/backtest/_validation/zipline_runner.py
+++ b/src/ml4t/backtest/_validation/zipline_runner.py
@@ -1,0 +1,374 @@
+"""Shared Zipline helpers for internal validation workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import os
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass
+class ZiplineRunResult:
+    """Standardized Zipline run artifacts for benchmark consumers."""
+
+    final_value: float
+    num_trades: int
+    trades_df: pd.DataFrame | None
+    positions_df: pd.DataFrame | None
+    transactions_df: pd.DataFrame | None
+    orders_df: pd.DataFrame | None
+    setup_time_sec: float = 0.0
+
+
+def load_zipline_modules() -> dict[str, Any]:
+    """Import and return the Zipline modules used by the validation runner."""
+    zipline_api = importlib.import_module("zipline.api")
+    return {
+        "run_algorithm": importlib.import_module("zipline").run_algorithm,
+        "get_datetime": zipline_api.get_datetime,
+        "order_target": zipline_api.order_target,
+        "set_commission": zipline_api.set_commission,
+        "set_max_leverage": zipline_api.set_max_leverage,
+        "set_slippage": zipline_api.set_slippage,
+        "sid": zipline_api.sid,
+        "ingest": importlib.import_module("zipline.data.bundles").ingest,
+        "register": importlib.import_module("zipline.data.bundles").register,
+        "NoCommission": importlib.import_module("zipline.finance.commission").NoCommission,
+        "PerDollar": importlib.import_module("zipline.finance.commission").PerDollar,
+        "SlippageModel": importlib.import_module("zipline.finance.slippage").SlippageModel,
+        "get_calendar": importlib.import_module("zipline.utils.calendar_utils").get_calendar,
+    }
+
+
+def normalize_target_lookup(
+    target_lookup_raw: dict[pd.Timestamp, dict[str, float]],
+) -> dict[pd.Timestamp, dict[str, float]]:
+    """Normalize target timestamps to tz-naive daily lookup keys."""
+    target_lookup: dict[pd.Timestamp, dict[str, float]] = {}
+    for ts, targets in target_lookup_raw.items():
+        ts_naive = ts.tz_convert(None) if ts.tz is not None else ts
+        target_lookup[pd.Timestamp(ts_naive).normalize()] = targets
+    return target_lookup
+
+
+def flatten_result_column(results: pd.DataFrame, column_name: str) -> pd.DataFrame:
+    """Flatten Zipline's list-valued result columns into a DataFrame."""
+    records: list[dict[str, object]] = []
+    if column_name not in results.columns:
+        return pd.DataFrame()
+
+    for dt, payload in results[column_name].items():
+        if not isinstance(payload, list):
+            continue
+        for item in payload:
+            if isinstance(item, dict):
+                record = dict(item)
+            elif hasattr(item, "to_dict"):
+                record = item.to_dict()
+            elif hasattr(item, "items"):
+                record = dict(item.items())
+            else:
+                continue
+            record["dt"] = dt
+            records.append(record)
+
+    return pd.DataFrame(records)
+
+
+def transactions_to_trade_log(transactions: pd.DataFrame) -> pd.DataFrame | None:
+    """Convert Zipline transactions into completed round-trip trades."""
+    if transactions.empty:
+        return None
+
+    transactions = transactions.copy()
+    transactions["dt"] = pd.to_datetime(transactions["dt"])
+    amount_col = "amount" if "amount" in transactions.columns else "filled"
+    price_col = "price" if "price" in transactions.columns else "last_sale_price"
+    symbol_col = (
+        "symbol"
+        if "symbol" in transactions.columns
+        else "sid"
+        if "sid" in transactions.columns
+        else "asset"
+        if "asset" in transactions.columns
+        else None
+    )
+    if symbol_col is None or amount_col not in transactions.columns or price_col not in transactions.columns:
+        return None
+
+    trade_records: list[dict[str, object]] = []
+    for symbol in transactions[symbol_col].dropna().unique():
+        symbol_txns = transactions[transactions[symbol_col] == symbol].sort_values("dt")
+
+        running_pos = 0.0
+        entry_time = None
+        entry_price = None
+        entry_size = 0.0
+
+        for _, row in symbol_txns.iterrows():
+            amount = float(row[amount_col])
+            price = float(row[price_col])
+            prev_pos = running_pos
+            running_pos += amount
+
+            if prev_pos == 0 and running_pos != 0:
+                entry_time = row["dt"]
+                entry_price = price
+                entry_size = amount
+            elif prev_pos != 0 and running_pos == 0:
+                assert entry_time is not None
+                assert entry_price is not None
+                pnl = (price - entry_price) * entry_size
+                trade_records.append(
+                    {
+                        "entry_date": entry_time,
+                        "exit_date": row["dt"],
+                        "asset": str(symbol),
+                        "side": "long" if entry_size > 0 else "short",
+                        "quantity": abs(entry_size),
+                        "entry_price": entry_price,
+                        "exit_price": price,
+                        "pnl": pnl,
+                    }
+                )
+                entry_time = None
+                entry_price = None
+            elif prev_pos != 0 and running_pos != 0 and (prev_pos > 0) != (running_pos > 0):
+                assert entry_time is not None
+                assert entry_price is not None
+                pnl = (price - entry_price) * entry_size
+                trade_records.append(
+                    {
+                        "entry_date": entry_time,
+                        "exit_date": row["dt"],
+                        "asset": str(symbol),
+                        "side": "long" if entry_size > 0 else "short",
+                        "quantity": abs(entry_size),
+                        "entry_price": entry_price,
+                        "exit_price": price,
+                        "pnl": pnl,
+                    }
+                )
+                entry_time = row["dt"]
+                entry_price = price
+                entry_size = running_pos
+
+    if not trade_records:
+        return None
+    return pd.DataFrame(trade_records).sort_values("entry_date").reset_index(drop=True)
+
+
+def run_zipline_target_shares(
+    *,
+    modules: dict[str, Any],
+    config: Any,
+    price_data: dict[str, pd.DataFrame],
+    dates: pd.DatetimeIndex,
+    target_lookup_raw: dict[pd.Timestamp, dict[str, float]],
+    logger: Any | None = None,
+) -> ZiplineRunResult:
+    """Run a canonical target-share strategy through Zipline Reloaded."""
+    log = logger or (lambda *_args, **_kwargs: None)
+
+    run_algorithm = modules["run_algorithm"]
+    get_datetime = modules["get_datetime"]
+    order_target = modules["order_target"]
+    set_commission = modules["set_commission"]
+    set_max_leverage = modules["set_max_leverage"]
+    set_slippage = modules["set_slippage"]
+    sid = modules["sid"]
+    ingest = modules["ingest"]
+    register = modules["register"]
+    NoCommission = modules["NoCommission"]
+    PerDollar = modules["PerDollar"]
+    SlippageModel = modules["SlippageModel"]
+    get_calendar = modules["get_calendar"]
+
+    nyse = get_calendar("XNYS")
+    asset_names = sorted(price_data.keys())
+    target_lookup = normalize_target_lookup(target_lookup_raw)
+
+    first_df = price_data[asset_names[0]]
+    start_date = first_df.index[0]
+    end_date = first_df.index[-1]
+    nyse_sessions = nyse.sessions_in_range(
+        pd.Timestamp(start_date).tz_localize(None) if pd.Timestamp(start_date).tz else start_date,
+        pd.Timestamp(end_date).tz_localize(None) if pd.Timestamp(end_date).tz else end_date,
+    )
+
+    class OpenPriceSlippage(SlippageModel):
+        @staticmethod
+        def process_order(data, order):
+            open_px = data.current(order.asset, "open")
+            if config.slippage_pct > 0:
+                if order.amount > 0:
+                    open_px = open_px * (1.0 + config.slippage_pct)
+                elif order.amount < 0:
+                    open_px = open_px * (1.0 - config.slippage_pct)
+            return (open_px, order.amount)
+
+    def make_multi_asset_ingest(price_data_dict, asset_list):
+        def ingest_func(
+            _environ,
+            asset_db_writer,
+            _minute_bar_writer,
+            daily_bar_writer,
+            adjustment_writer,
+            calendar,
+            start_session,
+            end_session,
+            _cache,
+            show_progress,
+            _output_dir,
+        ):
+            sessions = calendar.sessions_in_range(start_session, end_session)
+            sessions = pd.DatetimeIndex(sessions).tz_localize(None)
+
+            equities_df = pd.DataFrame(
+                {
+                    "symbol": asset_list,
+                    "asset_name": [f"Asset {name}" for name in asset_list],
+                    "exchange": ["NYSE"] * len(asset_list),
+                }
+            )
+            asset_db_writer.write(equities=equities_df)
+
+            bar_data = []
+            for asset_sid, asset_name in enumerate(asset_list):
+                df = price_data_dict[asset_name].copy()
+                if df.index.tz is not None:
+                    df.index = df.index.tz_convert(None)
+                trading_df = (
+                    df.reindex(sessions).ffill().bfill()[["open", "high", "low", "close", "volume"]]
+                )
+                if len(trading_df) > 0:
+                    bar_data.append((asset_sid, trading_df))
+
+            daily_bar_writer.write(bar_data, show_progress=show_progress)
+            adjustment_writer.write()
+
+        return ingest_func
+
+    bundle_sig_input = (
+        "|".join(asset_names) + f"|{pd.Timestamp(dates[0]).date()}|{pd.Timestamp(dates[-1]).date()}"
+    )
+    bundle_sig = hashlib.md5(bundle_sig_input.encode("utf-8")).hexdigest()[:10]
+    bundle_name = f"bench_multi_{len(asset_names)}_{config.n_bars}_{bundle_sig}"
+    start_session = nyse_sessions[0]
+    end_session = (
+        nyse_sessions[-1]
+        if len(nyse_sessions) <= config.n_bars
+        else nyse_sessions[config.n_bars - 1]
+    )
+
+    zipline_root = Path(os.environ.get("ZIPLINE_ROOT", Path.home() / ".zipline"))
+    bundle_dir = zipline_root / "data" / bundle_name
+    bundle_exists = False
+    if bundle_dir.exists() and any(bundle_dir.iterdir()):
+        bundle_runs = sorted(path for path in bundle_dir.iterdir() if path.is_dir())
+        if bundle_runs:
+            latest_run = bundle_runs[-1]
+            assets_ok = any(latest_run.glob("assets-*.sqlite"))
+            if assets_ok:
+                bundle_exists = True
+            else:
+                shutil.rmtree(bundle_dir, ignore_errors=True)
+
+    setup_time_sec = 0.0
+    if not bundle_exists:
+        bundle_start = time.perf_counter()
+        register(
+            bundle_name,
+            make_multi_asset_ingest(price_data, asset_names),
+            calendar_name="XNYS",
+            start_session=start_session,
+            end_session=end_session,
+        )
+        ingest(bundle_name, show_progress=False)
+        setup_time_sec = time.perf_counter() - bundle_start
+        log(f"  Bundle creation: {setup_time_sec:.1f}s (one-time setup)")
+    else:
+        log(f"  Using cached bundle: {bundle_name}")
+        register(
+            bundle_name,
+            make_multi_asset_ingest(price_data, asset_names),
+            calendar_name="XNYS",
+            start_session=start_session,
+            end_session=end_session,
+        )
+
+    algo_state = {
+        "target_lookup": target_lookup,
+        "asset_names": asset_names,
+    }
+
+    def initialize(context):
+        context.state = algo_state
+        context.assets = [sid(i) for i in range(len(context.state["asset_names"]))]
+        context.asset_map = {
+            name: context.assets[i] for i, name in enumerate(context.state["asset_names"])
+        }
+        context.name_by_asset = {asset: name for name, asset in context.asset_map.items()}
+        if config.commission_pct > 0:
+            set_commission(PerDollar(cost=config.commission_pct))
+        else:
+            set_commission(NoCommission())
+        if config.zipline_max_leverage is not None:
+            set_max_leverage(config.zipline_max_leverage)
+        set_slippage(OpenPriceSlippage())
+
+    def handle_data(context, data):
+        dt = get_datetime()
+        dt_naive = dt.tz_convert(None) if dt.tz else dt
+        dt_normalized = dt_naive.normalize()
+
+        targets = context.state["target_lookup"].get(dt_normalized, {})
+        active_names = set(targets.keys())
+        for asset_obj, position in context.portfolio.positions.items():
+            if position.amount != 0:
+                asset_name = context.name_by_asset.get(asset_obj)
+                if asset_name is not None:
+                    active_names.add(asset_name)
+
+        for asset_name in sorted(active_names):
+            asset = context.asset_map[asset_name]
+            if not data.can_trade(asset):
+                continue
+
+            current_pos = context.portfolio.positions[asset].amount
+            target = targets.get(asset_name, 0.0)
+            if current_pos != target:
+                order_target(asset, target)
+
+    results = run_algorithm(
+        start=start_session,
+        end=end_session,
+        initialize=initialize,
+        handle_data=handle_data,
+        capital_base=config.initial_cash,
+        bundle=bundle_name,
+        data_frequency="daily",
+    )
+
+    positions = flatten_result_column(results, "positions")
+    transactions = flatten_result_column(results, "transactions")
+    orders = flatten_result_column(results, "orders")
+    trades_df = transactions_to_trade_log(transactions)
+    num_trades = len(trades_df) if trades_df is not None else int(len(orders)) if not orders.empty else 0
+
+    return ZiplineRunResult(
+        final_value=float(results["portfolio_value"].iloc[-1]),
+        num_trades=num_trades,
+        trades_df=trades_df,
+        positions_df=positions if not positions.empty else None,
+        transactions_df=transactions if not transactions.empty else None,
+        orders_df=orders if not orders.empty else None,
+        setup_time_sec=setup_time_sec,
+    )

--- a/src/ml4t/backtest/broker.py
+++ b/src/ml4t/backtest/broker.py
@@ -83,6 +83,7 @@ class Broker:
         next_bar_submission_precheck: bool = False,
         next_bar_simple_cash_check: bool = False,
         buying_power_reservation: bool = False,
+        next_bar_queue_shadow_validation: bool = False,
         immediate_fill: bool = False,
         reject_on_insufficient_cash: bool = True,
         skip_cash_validation: bool = False,
@@ -125,6 +126,7 @@ class Broker:
         self.next_bar_submission_precheck = next_bar_submission_precheck
         self.next_bar_simple_cash_check = next_bar_simple_cash_check
         self.buying_power_reservation = buying_power_reservation
+        self.next_bar_queue_shadow_validation = next_bar_queue_shadow_validation
         self.immediate_fill = immediate_fill
         self.reject_on_insufficient_cash = reject_on_insufficient_cash
         self.skip_cash_validation = skip_cash_validation
@@ -343,6 +345,7 @@ class Broker:
             next_bar_submission_precheck=config.next_bar_submission_precheck,
             next_bar_simple_cash_check=config.next_bar_simple_cash_check,
             buying_power_reservation=config.buying_power_reservation,
+            next_bar_queue_shadow_validation=config.next_bar_queue_shadow_validation,
             immediate_fill=config.immediate_fill,
             reject_on_insufficient_cash=config.reject_on_insufficient_cash,
             skip_cash_validation=config.skip_cash_validation,

--- a/src/ml4t/backtest/config.py
+++ b/src/ml4t/backtest/config.py
@@ -532,6 +532,7 @@ class BacktestConfig:
     next_bar_submission_precheck: bool = False
     next_bar_simple_cash_check: bool = False
     buying_power_reservation: bool = False  # Reserve cash at submission (LEAN-style)
+    next_bar_queue_shadow_validation: bool = False
     immediate_fill: bool = False  # Fill same-bar market orders at submit time (LEAN-style)
     rebalance_mode: RebalanceMode = RebalanceMode.INCREMENTAL
     rebalance_headroom_pct: float = 1.0
@@ -701,6 +702,7 @@ class BacktestConfig:
                 "next_bar_submission_precheck": self.next_bar_submission_precheck,
                 "next_bar_simple_cash_check": self.next_bar_simple_cash_check,
                 "buying_power_reservation": self.buying_power_reservation,
+                "next_bar_queue_shadow_validation": self.next_bar_queue_shadow_validation,
                 "immediate_fill": self.immediate_fill,
                 "rebalance_mode": self.rebalance_mode.value,
                 "rebalance_headroom_pct": self.rebalance_headroom_pct,
@@ -783,6 +785,7 @@ class BacktestConfig:
                     "next_bar_submission_precheck",
                     "next_bar_simple_cash_check",
                     "buying_power_reservation",
+                    "next_bar_queue_shadow_validation",
                     "immediate_fill",
                     "rebalance_mode",
                     "rebalance_headroom_pct",
@@ -903,6 +906,9 @@ class BacktestConfig:
             next_bar_submission_precheck=order_cfg.get("next_bar_submission_precheck", False),
             next_bar_simple_cash_check=order_cfg.get("next_bar_simple_cash_check", False),
             buying_power_reservation=order_cfg.get("buying_power_reservation", False),
+            next_bar_queue_shadow_validation=order_cfg.get(
+                "next_bar_queue_shadow_validation", False
+            ),
             immediate_fill=order_cfg.get("immediate_fill", False),
             rebalance_mode=RebalanceMode(order_cfg.get("rebalance_mode", "incremental")),
             rebalance_headroom_pct=order_cfg.get("rebalance_headroom_pct", 1.0),
@@ -1010,6 +1016,7 @@ class BacktestConfig:
                 f"  Entry priority: {self.entry_order_priority.value}",
                 f"  Next-bar precheck: {self.next_bar_submission_precheck}",
                 f"  Next-bar cash check: {self.next_bar_simple_cash_check}",
+                f"  Next-bar queue shadow validation: {self.next_bar_queue_shadow_validation}",
                 f"  Rebalance mode: {self.rebalance_mode.value}",
                 f"  Rebalance headroom: {self.rebalance_headroom_pct:.3f}",
                 f"  Missing price policy: {self.missing_price_policy.value}",

--- a/src/ml4t/backtest/core/execution_engine.py
+++ b/src/ml4t/backtest/core/execution_engine.py
@@ -192,14 +192,18 @@ class ExecutionEngine:
         broker = self.broker
         policy = broker.account.policy
         qty_delta = order.quantity if order.side is OrderSide.BUY else -order.quantity
-        current_qty = shadow_positions[order.asset].quantity if order.asset in shadow_positions else 0.0
+        current_qty = (
+            shadow_positions[order.asset].quantity if order.asset in shadow_positions else 0.0
+        )
         new_qty = current_qty + qty_delta
         is_reversal = (
             abs(current_qty) > 1e-12
             and abs(new_qty) > 1e-12
             and ((current_qty > 0 and new_qty < 0) or (current_qty < 0 and new_qty > 0))
         )
-        commission = broker.commission_model.calculate(order.asset, order.quantity, validation_price)
+        commission = broker.commission_model.calculate(
+            order.asset, order.quantity, validation_price
+        )
 
         if abs(current_qty) <= 1e-12:
             return policy.validate_new_position(
@@ -238,7 +242,9 @@ class ExecutionEngine:
     ) -> float:
         broker = self.broker
         qty_delta = order.quantity if order.side is OrderSide.BUY else -order.quantity
-        current_qty = shadow_positions[order.asset].quantity if order.asset in shadow_positions else 0.0
+        current_qty = (
+            shadow_positions[order.asset].quantity if order.asset in shadow_positions else 0.0
+        )
         new_qty = current_qty + qty_delta
         commission = broker.commission_model.calculate(order.asset, order.quantity, fill_price)
         shadow_cash += -qty_delta * fill_price * broker.get_multiplier(order.asset) - commission

--- a/src/ml4t/backtest/core/execution_engine.py
+++ b/src/ml4t/backtest/core/execution_engine.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from ..types import ExecutionMode, OrderSide, OrderStatus, OrderType
+import copy
+
+from ..types import ExecutionMode, OrderSide, OrderStatus, OrderType, Position
 from .shared import is_exit_order
 
 
@@ -13,6 +15,10 @@ class ExecutionEngine:
         self.broker = broker
 
     def process_orders(self, use_open: bool = False):
+        if self._should_use_next_bar_queue_shadow_validation(use_open):
+            self._process_orders_next_bar_queue_shadow(use_open)
+            return
+
         ordering = self.broker.fill_ordering.value
         if ordering == "exit_first":
             self._process_orders_exit_first(use_open)
@@ -30,6 +36,7 @@ class ExecutionEngine:
         fill = broker._fill_engine
         exit_orders = []
         entry_orders = []
+        eligible_orders = []
         orders_this_bar_ids = broker._orders_this_bar_ids
 
         for order in broker.pending_orders[:]:
@@ -38,14 +45,25 @@ class ExecutionEngine:
                 and order.order_id in orders_this_bar_ids
             ):
                 continue
+            eligible_orders.append(order)
             if self._is_exit_order(order):
                 exit_orders.append(order)
             else:
                 entry_orders.append(order)
 
         filled_orders: list = []
+        deferred_entries: list = []
 
         for order in exit_orders:
+            if order.status is not OrderStatus.PENDING:
+                continue
+            # Exit classification must be re-evaluated at fill time. Multiple
+            # queued orders for the same asset can exhaust the current
+            # position; later orders then become reversals/new entries and must
+            # go through the normal entry validation path.
+            if not self._is_exit_order(order):
+                deferred_entries.append(order)
+                continue
             price = fill.get_fill_price_for_order(order, use_open)
             if price is None:
                 continue
@@ -59,12 +77,199 @@ class ExecutionEngine:
                     fill.update_partial_order(order)
 
         broker.mark_account_positions(use_open=use_open)
+        if deferred_entries:
+            entry_order_ids = {order.order_id for order in entry_orders}
+            entry_order_ids.update(order.order_id for order in deferred_entries)
+            entry_orders = [order for order in eligible_orders if order.order_id in entry_order_ids]
         entry_orders = self._sort_entry_orders(entry_orders, use_open=use_open)
 
         for order in entry_orders:
             self._process_single_order(order, use_open, filled_orders)
 
         self._cleanup_filled_orders(filled_orders)
+
+    def _should_use_next_bar_queue_shadow_validation(self, use_open: bool) -> bool:
+        broker = self.broker
+        if not (
+            use_open
+            and broker.execution_mode is ExecutionMode.NEXT_BAR
+            and broker.next_bar_queue_shadow_validation
+        ):
+            return False
+
+        current_bar_index = broker._bar_index
+        for order in broker.pending_orders:
+            if order.order_id in broker._orders_this_bar_ids:
+                continue
+            if getattr(order, "_created_bar_index", current_bar_index) < current_bar_index - 1:
+                return True
+
+        return False
+
+    def _process_orders_next_bar_queue_shadow(self, use_open: bool = False):
+        broker = self.broker
+        fill = broker._fill_engine
+        eligible_orders = []
+        orders_this_bar_ids = broker._orders_this_bar_ids
+
+        for order in broker.pending_orders[:]:
+            if (
+                broker.execution_mode is ExecutionMode.NEXT_BAR
+                and order.order_id in orders_this_bar_ids
+            ):
+                continue
+            eligible_orders.append(order)
+
+        if not eligible_orders:
+            return
+
+        shadow_cash = broker.account.cash
+        shadow_positions = {
+            asset: copy.deepcopy(position) for asset, position in broker.account.positions.items()
+        }
+        for asset, position in shadow_positions.items():
+            mark = broker._current_prices.get(asset)
+            if mark is not None:
+                position.current_price = mark
+
+        accepted_orders: list[tuple[object, float]] = []
+        filled_orders: list = []
+
+        for order in eligible_orders:
+            price = fill.get_fill_price_for_order(order, use_open)
+            if price is None:
+                continue
+
+            fill.apply_share_rounding(order)
+            if order.quantity <= 0:
+                order.status = OrderStatus.REJECTED
+                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
+                continue
+
+            fill_price = fill.check_fill(order, price)
+            if fill_price is None:
+                continue
+
+            validation_price = broker._current_prices.get(order.asset, fill_price)
+            valid, rejection_reason = self._validate_shadow_queue_order(
+                order=order,
+                validation_price=validation_price,
+                shadow_cash=shadow_cash,
+                shadow_positions=shadow_positions,
+            )
+            if not valid:
+                order.status = OrderStatus.REJECTED
+                order.rejection_reason = rejection_reason
+                continue
+
+            accepted_orders.append((order, fill_price))
+            shadow_cash = self._commit_shadow_queue_fill(
+                order=order,
+                fill_price=fill_price,
+                shadow_cash=shadow_cash,
+                shadow_positions=shadow_positions,
+            )
+
+        for order, fill_price in accepted_orders:
+            fully_filled = fill.execute_fill(order, fill_price)
+            if fully_filled:
+                filled_orders.append(order)
+                broker._partial_orders.pop(order.order_id, None)
+            else:
+                fill.update_partial_order(order)
+            broker.mark_account_positions(use_open=False)
+
+        self._cleanup_filled_orders(filled_orders)
+
+    def _validate_shadow_queue_order(
+        self,
+        *,
+        order,
+        validation_price: float,
+        shadow_cash: float,
+        shadow_positions: dict[str, Position],
+    ) -> tuple[bool, str]:
+        broker = self.broker
+        policy = broker.account.policy
+        qty_delta = order.quantity if order.side is OrderSide.BUY else -order.quantity
+        current_qty = shadow_positions[order.asset].quantity if order.asset in shadow_positions else 0.0
+        new_qty = current_qty + qty_delta
+        is_reversal = (
+            abs(current_qty) > 1e-12
+            and abs(new_qty) > 1e-12
+            and ((current_qty > 0 and new_qty < 0) or (current_qty < 0 and new_qty > 0))
+        )
+        commission = broker.commission_model.calculate(order.asset, order.quantity, validation_price)
+
+        if abs(current_qty) <= 1e-12:
+            return policy.validate_new_position(
+                asset=order.asset,
+                quantity=qty_delta,
+                price=validation_price,
+                current_positions=shadow_positions,
+                cash=shadow_cash - commission,
+            )
+        if is_reversal:
+            return policy.handle_reversal(
+                asset=order.asset,
+                current_quantity=current_qty,
+                order_quantity_delta=qty_delta,
+                price=validation_price,
+                current_positions=shadow_positions,
+                cash=shadow_cash,
+                commission=commission,
+            )
+        return policy.validate_position_change(
+            asset=order.asset,
+            current_quantity=current_qty,
+            quantity_delta=qty_delta,
+            price=validation_price,
+            current_positions=shadow_positions,
+            cash=shadow_cash - commission,
+        )
+
+    def _commit_shadow_queue_fill(
+        self,
+        *,
+        order,
+        fill_price: float,
+        shadow_cash: float,
+        shadow_positions: dict[str, Position],
+    ) -> float:
+        broker = self.broker
+        qty_delta = order.quantity if order.side is OrderSide.BUY else -order.quantity
+        current_qty = shadow_positions[order.asset].quantity if order.asset in shadow_positions else 0.0
+        new_qty = current_qty + qty_delta
+        commission = broker.commission_model.calculate(order.asset, order.quantity, fill_price)
+        shadow_cash += -qty_delta * fill_price * broker.get_multiplier(order.asset) - commission
+
+        if abs(new_qty) <= 1e-12:
+            shadow_positions.pop(order.asset, None)
+            return shadow_cash
+
+        position = shadow_positions.get(order.asset)
+        if position is None:
+            shadow_positions[order.asset] = Position(
+                asset=order.asset,
+                quantity=new_qty,
+                entry_price=fill_price,
+                entry_time=broker._current_time,
+                current_price=broker._current_prices.get(order.asset, fill_price),
+                multiplier=broker.get_multiplier(order.asset),
+            )
+            return shadow_cash
+
+        is_reversal = (
+            abs(current_qty) > 1e-12
+            and abs(new_qty) > 1e-12
+            and ((current_qty > 0 and new_qty < 0) or (current_qty < 0 and new_qty > 0))
+        )
+        position.quantity = new_qty
+        position.current_price = broker._current_prices.get(order.asset, fill_price)
+        if abs(current_qty) <= 1e-12 or is_reversal:
+            position.entry_price = fill_price
+
+        return shadow_cash
 
     def _process_orders_fifo(self, use_open: bool = False):
         broker = self.broker
@@ -119,6 +324,9 @@ class ExecutionEngine:
         shadow_validated = broker.buying_power_reservation
 
         for order in eligible_orders:
+            if order.status is not OrderStatus.PENDING:
+                continue
+
             price = fill.get_fill_price_for_order(order, use_open)
             if price is None:
                 continue
@@ -154,6 +362,8 @@ class ExecutionEngine:
     def _process_single_order(self, order, use_open: bool, filled_orders: list) -> None:
         broker = self.broker
         fill = broker._fill_engine
+        if order.status is not OrderStatus.PENDING:
+            return
         price = fill.get_fill_price_for_order(order, use_open)
         if price is None:
             return

--- a/src/ml4t/backtest/core/order_book.py
+++ b/src/ml4t/backtest/core/order_book.py
@@ -61,6 +61,7 @@ class OrderBook:
             rebalance_id=options.rebalance_id if options is not None else None,
             order_id=f"ORD-{broker._order_counter}",
             created_at=broker._current_time,
+            _created_bar_index=broker._bar_index,
         )
 
         order._signal_price = broker._current_prices.get(asset)

--- a/src/ml4t/backtest/profiles.py
+++ b/src/ml4t/backtest/profiles.py
@@ -178,6 +178,7 @@ ZIPLINE_PROFILE = {
         "partial_fills_allowed": True,
         "fill_ordering": "exit_first",
         "entry_order_priority": "submission",
+        "next_bar_queue_shadow_validation": True,
         "rebalance_mode": "snapshot",
         "rebalance_headroom_pct": 0.998,
         "missing_price_policy": "use_last",
@@ -252,12 +253,15 @@ ZIPLINE_STRICT_PROFILE["orders"]["entry_order_priority"] = "submission"
 LEAN_PROFILE = {
     "account": {
         "allow_short_selling": True,
-        "allow_leverage": False,
+        "allow_leverage": True,
+        "initial_margin": 0.5,
+        "long_maintenance_margin": 0.25,
+        "short_maintenance_margin": 0.30,
         "short_cash_policy": "credit",
     },
     "execution": {
-        "execution_price": "close",
-        "execution_mode": "same_bar",
+        "execution_price": "open",
+        "execution_mode": "next_bar",
     },
     "stops": {
         "stop_fill_mode": "stop_price",
@@ -287,6 +291,7 @@ LEAN_PROFILE = {
         "partial_fills_allowed": False,
         "fill_ordering": "exit_first",
         "entry_order_priority": "submission",
+        "next_bar_queue_shadow_validation": True,
         "rebalance_mode": "snapshot",
         "rebalance_headroom_pct": 1.0,
         "missing_price_policy": "use_last",
@@ -294,10 +299,6 @@ LEAN_PROFILE = {
         "late_asset_min_bars": 1,
     },
 }
-
-LEAN_STRICT_PROFILE = deepcopy(LEAN_PROFILE)
-LEAN_STRICT_PROFILE["orders"]["buying_power_reservation"] = True
-LEAN_STRICT_PROFILE["settlement"] = {"delay": 2}  # T+2 for US equities
 
 FAST_PROFILE = {
     "account": {
@@ -354,7 +355,6 @@ _PROFILES = {
     "vectorbt_strict": VECTORBT_STRICT_PROFILE,
     "backtrader_strict": BACKTRADER_STRICT_PROFILE,
     "zipline_strict": ZIPLINE_STRICT_PROFILE,
-    "lean_strict": LEAN_STRICT_PROFILE,
 }
 
 _ALIASES = {
@@ -364,7 +364,7 @@ _ALIASES = {
     "vectorbt_compare": "vectorbt_strict",
     "backtrader_compare": "backtrader_strict",
     "zipline_compare": "zipline_strict",
-    "lean_compare": "lean_strict",
+    "lean_compare": "lean",
 }
 
 _CORE_PROFILE_NAMES = ["backtrader", "default", "lean", "realistic", "vectorbt", "zipline"]

--- a/src/ml4t/backtest/types.py
+++ b/src/ml4t/backtest/types.py
@@ -154,6 +154,7 @@ class Order:
     filled_quantity: float = 0.0
     rejection_reason: str | None = None  # Reason if order was rejected
     # Internal risk management fields (set by broker)
+    _created_bar_index: int = 0
     _signal_price: float | None = None  # Close price at order creation time
     _risk_exit_reason: str | None = None  # Human-readable reason (legacy, for logging)
     _exit_reason: ExitReason | None = None  # Typed exit reason (preferred)

--- a/tests/benchmark/test_backtrader_zipline_runners.py
+++ b/tests/benchmark/test_backtrader_zipline_runners.py
@@ -1,0 +1,87 @@
+"""Tests for shared Backtrader and Zipline validation runners."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ml4t.backtest._validation.backtrader_runner import transactions_to_trade_log as bt_trade_log
+from ml4t.backtest._validation.zipline_runner import (
+    flatten_result_column,
+    normalize_target_lookup,
+)
+from ml4t.backtest._validation.zipline_runner import (
+    transactions_to_trade_log as zipline_trade_log,
+)
+
+
+def test_backtrader_transactions_to_trade_log_handles_flip():
+    transactions = pd.DataFrame(
+        {
+            "amount": [10, -15, 5],
+            "price": [100.0, 110.0, 108.0],
+            "symbol": ["AAPL", "AAPL", "AAPL"],
+        },
+        index=pd.to_datetime(["2024-01-02", "2024-01-03", "2024-01-04"]),
+    )
+
+    trades_df = bt_trade_log(transactions)
+
+    assert trades_df is not None
+    assert len(trades_df) == 2
+    assert trades_df["side"].tolist() == ["long", "short"]
+    assert trades_df["quantity"].tolist() == [10.0, 5.0]
+    assert trades_df["entry_price"].tolist() == [100.0, 110.0]
+    assert trades_df["exit_price"].tolist() == [110.0, 108.0]
+
+
+def test_zipline_normalize_target_lookup_strips_timezone():
+    target_lookup_raw = {
+        pd.Timestamp("2024-01-02", tz="UTC"): {"AAPL": 100.0},
+        pd.Timestamp("2024-01-03"): {"MSFT": -50.0},
+    }
+
+    normalized = normalize_target_lookup(target_lookup_raw)
+
+    assert list(normalized.keys()) == [
+        pd.Timestamp("2024-01-02"),
+        pd.Timestamp("2024-01-03"),
+    ]
+
+
+def test_zipline_flatten_result_column_reads_list_payloads():
+    results = pd.DataFrame(
+        {
+            "transactions": [
+                [{"symbol": "AAPL", "amount": 10, "price": 100.0}],
+                [{"symbol": "AAPL", "amount": -10, "price": 101.0}],
+            ]
+        },
+        index=pd.to_datetime(["2024-01-02", "2024-01-03"]),
+    )
+
+    flattened = flatten_result_column(results, "transactions")
+
+    assert flattened["symbol"].tolist() == ["AAPL", "AAPL"]
+    assert flattened["amount"].tolist() == [10, -10]
+    assert pd.to_datetime(flattened["dt"]).tolist() == list(results.index)
+
+
+def test_zipline_transactions_to_trade_log_handles_round_trip():
+    transactions = pd.DataFrame(
+        {
+            "dt": pd.to_datetime(["2024-01-02", "2024-01-03"]),
+            "amount": [10.0, -10.0],
+            "price": [100.0, 102.0],
+            "symbol": ["AAPL", "AAPL"],
+        }
+    )
+
+    trades_df = zipline_trade_log(transactions)
+
+    assert trades_df is not None
+    assert len(trades_df) == 1
+    record = trades_df.iloc[0]
+    assert record["asset"] == "AAPL"
+    assert record["side"] == "long"
+    assert record["quantity"] == 10.0
+    assert record["pnl"] == 20.0

--- a/tests/benchmark/test_lean_adapter.py
+++ b/tests/benchmark/test_lean_adapter.py
@@ -1,0 +1,78 @@
+"""Tests for the LEAN benchmark adapter helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_benchmark_suite():
+    suite_path = Path(__file__).resolve().parents[2] / "validation" / "benchmark_suite.py"
+    module_name = "ml4t_validation_benchmark_suite_lean"
+    spec = importlib.util.spec_from_file_location(module_name, suite_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_lean_artifacts_reads_summary_and_surfaces(tmp_path):
+    suite = _load_benchmark_suite()
+
+    summary = {
+        "totalPerformance": {
+            "tradeStatistics": {"totalNumberOfTrades": "0"},
+            "portfolioStatistics": {"endEquity": "$0"},
+        },
+        "statistics": {"Total Orders": "0", "End Equity": "$0"},
+        "state": {"OrderCount": "0"},
+    }
+    (tmp_path / "result-summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    (tmp_path / "ml4t_symbol_map.json").write_text(
+        json.dumps({"AAAA": "AAPL"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "ml4t_daily_equity.csv").write_text(
+        "timestamp,equity,cash,total_fees,holdings_value\n"
+        "2024-01-02,100000,100000,0,0\n"
+        "2024-01-03,100250,25000,4.5,75250\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "ml4t_order_events.csv").write_text(
+        "timestamp,symbol,status,direction,fill_quantity,fill_price,fee,message,order_id\n"
+        "2024-01-02 00:00:00,AAAA,Filled,Buy,10,100,1.0,,1\n"
+        "2024-01-03 00:00:00,AAAA,PartiallyFilled,Sell,-4,101,0.5,partial,2\n"
+        "2024-01-03 00:00:00,AAAA,Submitted,Sell,0,0,0.0,pending,2\n",
+        encoding="utf-8",
+    )
+
+    num_trades, final_value, trades_df, equity_df, order_events_df = suite._load_lean_artifacts(
+        tmp_path
+    )
+
+    assert num_trades == 2
+    assert final_value == 100250.0
+    assert trades_df is not None
+    assert list(trades_df["asset"]) == ["AAPL", "AAPL"]
+    assert list(trades_df["side"]) == ["buy", "sell"]
+    assert list(trades_df["quantity"]) == [10, 4]
+    assert equity_df is not None
+    assert list(equity_df["equity"]) == [100000, 100250]
+    assert order_events_df is not None
+    assert len(order_events_df) == 3
+    assert list(order_events_df["asset"]) == ["AAPL", "AAPL", "AAPL"]
+
+
+def test_load_lean_artifacts_requires_summary(tmp_path):
+    suite = _load_benchmark_suite()
+
+    try:
+        suite._load_lean_artifacts(tmp_path)
+    except FileNotFoundError as exc:
+        assert "summary file not found" in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError when LEAN summary is missing")

--- a/tests/contracts/test_profile_parity_basics.py
+++ b/tests/contracts/test_profile_parity_basics.py
@@ -102,11 +102,13 @@ def test_profile_registry_has_lean_profile() -> None:
 
 
 def test_lean_profile_is_independent_of_backtrader() -> None:
-    """LEAN profile must NOT inherit from Backtrader (allow_leverage differs)."""
+    """LEAN profile must remain distinct from Backtrader on execution semantics."""
     lean = BacktestConfig.from_preset("lean")
     bt = BacktestConfig.from_preset("backtrader")
-    assert lean.allow_leverage is False
-    assert bt.allow_leverage is True
+    assert lean.fill_ordering.value == "exit_first"
+    assert bt.fill_ordering.value == "fifo"
+    assert lean.commission_per_share == 0.005
+    assert bt.commission_rate == 0.001
 
 
 def test_quantconnect_alias_resolves_to_lean() -> None:

--- a/tests/test_config_wiring.py
+++ b/tests/test_config_wiring.py
@@ -12,6 +12,7 @@ Validates that BacktestConfig fields actually affect execution:
 from datetime import datetime
 
 import pytest
+from ml4t.data.artifacts.market_data import FeedSpec
 
 from ml4t.backtest import (
     BacktestConfig,
@@ -37,7 +38,6 @@ from ml4t.backtest.models import (
     VolumeShareSlippage,
 )
 from ml4t.backtest.types import OrderSide, Position
-from ml4t.data.artifacts.market_data import FeedSpec
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -368,10 +368,11 @@ class TestShortCashPolicy:
         assert config.next_bar_submission_precheck is True
         assert config.next_bar_simple_cash_check is True
 
-    def test_lean_strict_profile_uses_buying_power_settlement(self):
-        config = BacktestConfig.from_preset("lean_strict")
-        assert config.buying_power_reservation is True
-        assert config.settlement_delay == 2
+    def test_lean_profile_uses_margin_next_bar_open(self):
+        config = BacktestConfig.from_preset("lean")
+        assert config.allow_leverage is True
+        assert config.execution_mode == ExecutionMode.NEXT_BAR
+        assert config.execution_price == ExecutionPrice.OPEN
 
     def test_lock_notional_reversal_obeys_partial_cash_cap(self):
         broker = _make_broker(
@@ -483,6 +484,58 @@ class TestFillOrdering:
         # EXIT_FIRST: AAPL sell frees $10k, then GOOG buy succeeds
         assert broker.get_position("AAPL") is None
         assert broker.get_position("GOOG") is not None
+
+    def test_exit_first_reclassifies_later_reversal_as_entry(self):
+        """Later same-asset orders must stop being exits once flat."""
+        broker = _make_broker(
+            initial_cash=10_000.0,
+            fill_ordering=FillOrdering.EXIT_FIRST,
+            allow_short_selling=False,
+            allow_leverage=False,
+        )
+        _set_prices(broker, {"AAPL": 100.0})
+
+        broker.submit_order("AAPL", 100, OrderSide.BUY)
+        broker._process_orders()
+        assert broker.get_position("AAPL") is not None
+
+        _set_prices(broker, {"AAPL": 100.0})
+        broker.submit_order("AAPL", 80, OrderSide.SELL)
+        broker.submit_order("AAPL", 80, OrderSide.SELL)
+        broker._process_orders()
+
+        pos = broker.get_position("AAPL")
+        assert pos is not None
+        assert pos.quantity == 20.0
+        rejected = [o for o in broker.orders if o.rejection_reason]
+        assert len(rejected) == 1
+
+    def test_exit_first_preserves_submission_order_for_deferred_entries(self):
+        """Deferred same-asset entries must keep their original submission order."""
+        broker = _make_broker(
+            initial_cash=20_000.0,
+            fill_ordering=FillOrdering.EXIT_FIRST,
+            entry_order_priority=EntryOrderPriority.SUBMISSION,
+            allow_short_selling=False,
+            allow_leverage=False,
+        )
+        _set_prices(broker, {"AAPL": 100.0})
+
+        broker.submit_order("AAPL", 100, OrderSide.BUY)
+        broker._process_orders()
+        assert broker.get_position("AAPL") is not None
+        assert broker.cash == 10_000.0
+
+        _set_prices(broker, {"AAPL": 100.0})
+        broker.submit_order("AAPL", 100, OrderSide.BUY)
+        broker.submit_order("AAPL", 100, OrderSide.SELL)
+        broker.submit_order("AAPL", 100, OrderSide.SELL)
+        broker._process_orders()
+
+        # Submission order must be: older buy first, then deferred sell.
+        assert broker.get_position("AAPL") is None
+        rejected = [o for o in broker.orders if o.rejection_reason]
+        assert rejected == []
 
 
 class TestEntryOrderPriority:
@@ -671,6 +724,12 @@ class TestPresetRoundTrip:
         assert config.share_type == ShareType.INTEGER
         assert config.cash_buffer_pct == 0.02
 
+    def test_lean_preset_values(self):
+        config = BacktestConfig.from_preset("lean")
+        assert config.share_type == ShareType.INTEGER
+        assert config.fill_ordering == FillOrdering.EXIT_FIRST
+        assert config.next_bar_queue_shadow_validation is True
+
     def test_to_dict_from_dict_roundtrip(self):
         config = BacktestConfig.from_preset("backtrader")
         d = config.to_dict()
@@ -680,6 +739,7 @@ class TestPresetRoundTrip:
         assert restored.cash_buffer_pct == config.cash_buffer_pct
         assert restored.reject_on_insufficient_cash == config.reject_on_insufficient_cash
         assert restored.partial_fills_allowed == config.partial_fills_allowed
+        assert restored.next_bar_queue_shadow_validation == config.next_bar_queue_shadow_validation
 
     def test_sizing_method_removed_from_fields(self):
         """sizing_method was removed from BacktestConfig fields."""
@@ -840,12 +900,6 @@ class TestImmediateFill:
         config = BacktestConfig(immediate_fill=True)
         broker = Broker.from_config(config)
         assert broker.immediate_fill is True
-
-    def test_lean_strict_profile_uses_buying_power_reservation(self):
-        config = BacktestConfig.from_preset("lean_strict")
-        assert config.buying_power_reservation is True
-        assert config.immediate_fill is False
-        assert config.settlement_delay == 2
 
     def test_to_dict_from_dict_roundtrip(self):
         config = BacktestConfig(immediate_fill=True, mark_price=ExecutionPrice.QUOTE_MID)

--- a/uv.lock
+++ b/uv.lock
@@ -2092,6 +2092,8 @@ requires-dist = [
     { name = "ml4t-backtest", marker = "extra == 'all'", editable = "." },
     { name = "ml4t-backtest", marker = "extra == 'backtest'", editable = "." },
     { name = "ml4t-data", editable = "../ml4t-data" },
+    { name = "ml4t-data", marker = "extra == 'all'", editable = "../ml4t-data" },
+    { name = "ml4t-data", marker = "extra == 'factors'", editable = "../ml4t-data" },
     { name = "ml4t-engineer", editable = "../ml4t-engineer" },
     { name = "numba", specifier = ">=0.57.0" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -2127,7 +2129,7 @@ requires-dist = [
     { name = "xgboost", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "xgboost", marker = "extra == 'ml'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["all", "backtest", "dashboard", "dev", "docs", "gpu", "ml", "tracking", "viz"]
+provides-extras = ["all", "backtest", "dashboard", "dev", "docs", "factors", "gpu", "ml", "tracking", "viz"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/validation/METHODOLOGY.md
+++ b/validation/METHODOLOGY.md
@@ -38,7 +38,7 @@ replicate that framework's behavior:
 | `vectorbt` / `vectorbt_strict` | VectorBT Pro/OSS | 0% trade gap, 0% value gap |
 | `backtrader` / `backtrader_strict` | Backtrader | 0% trade gap, 0% value gap |
 | `zipline` / `zipline_strict` | Zipline Reloaded | 0% trade gap, 0% value gap |
-| `lean` / `lean_strict` | QuantConnect LEAN | 0% trade gap, 0% value gap |
+| `lean` | QuantConnect LEAN | 0% fill gap, near-0% value gap |
 | `default` | ml4t's own opinion | Best-practice defaults |
 | `realistic` | Conservative simulation | Adds costs, integer shares |
 
@@ -209,15 +209,18 @@ previous close.
 
 ### "Strict" Profile Additions (for validation parity)
 
-| Knob | vbt_strict | bt_strict | zip_strict | lean_strict |
+| Knob | vbt_strict | bt_strict | zip_strict | lean |
 |------|-----------|-----------|------------|-------------|
 | `short_cash_policy` | **lock_notional** | credit | **credit** | credit |
 | `skip_cash_validation` | false | false | **true** | false |
 | `reject_on_insufficient_cash` | **true** | true | true | true |
 | `fill_ordering` | **fifo** | fifo | exit_first | **exit_first** |
-| `next_bar_submission_precheck` | -- | **true** | -- | **true** |
-| `next_bar_simple_cash_check` | -- | **true** | -- | **false** |
-| `allow_short_selling` | -- | -- | **true** | -- |
+| `next_bar_submission_precheck` | -- | **true** | -- | false |
+| `next_bar_simple_cash_check` | -- | **true** | -- | false |
+| `allow_short_selling` | -- | -- | **true** | **true** |
+| `allow_leverage` | -- | -- | -- | **true** |
+| `execution_mode` | -- | **next_bar** | **next_bar** | **next_bar** |
+| `execution_price` | -- | **open** | **open** | **open** |
 
 ---
 
@@ -229,17 +232,17 @@ Validated on both synthetic and **real market data** (250 US equities, 1998-2018
 
 | Profile | ml4t Trades | Ext Trades | Trade Gap | ml4t Value | Ext Value | Value Gap | Speedup |
 |---------|-------------|------------|-----------|------------|-----------|-----------|---------|
-| **zipline_strict** | 226,723 | 226,723 | **0 (0.00%)** | -$18,846,482 | -$18,846,501 | **$19 (0.0001%)** | **8.4x** |
-| **backtrader_strict** | 216,980 | 216,981 | -1 (0.0005%) | $13,880,796 | $13,881,298 | $503 (0.004%) | **19.3x** |
+| **zipline_strict** | 226,723 | 226,723 | **0 (0.00%)** | $720,044.00 | $720,033.70 | **$10.30 (0.0014%)** | **8.0x** |
+| **backtrader_strict** | 226,535 | 226,535 | **0 (0.00%)** | $746,797.21 | $746,797.21 | **float noise** | **7.7x** |
 | **vectorbt_strict** | 210,352 | 210,261 | +91 (0.04%) | $135,539 | $135,539 | $0 (0.00%) | 0.04x |
-| **lean_strict** | 226,246 | 225,583 | +663 (0.29%) | $1,106,708 | $1,093,558 | $13,150 (1.2%) | **5.3x** |
+| **lean** | 428,459 fills | 428,459 fills | **0 (0.00%)** | $720,044.00 | $720,042.45 | **$1.55 (0.0002%)** | **3.4x** |
 
 ### Parity Confidence
 
 | Framework | Trade Diff (real) | Value Diff (real) | Confidence | Status |
 |-----------|-------------------|-------------------|------------|--------|
-| Zipline | **0 (0.00%)** | **$19 (0.0001%)** | **99.9%+** | DONE |
-| Backtrader | **-1 (0.0005%)** | $503 (0.004%) | **99%+** | Production |
+| Zipline | **0 (0.00%)** | **$10.30 (0.0014%)** | **99.9%+** | DONE |
+| Backtrader | **0 (0.00%)** | float noise | **99.9%+** | DONE |
 | VBT OSS | +91 (0.04%) | $0 (0.00%) | **99%+** | Production |
 | LEAN | +663 (0.29%) | $13K (1.2%) | **97%+** | Buying-power reservation gap |
 

--- a/validation/README.md
+++ b/validation/README.md
@@ -43,10 +43,10 @@ Data: `us_equities.parquet` (250 US equities, 1998-2018). Strategy: long top 25,
 
 | Profile | ml4t Trades | Ref Trades | Trade Gap | Value Gap | Speed |
 |---------|-------------|------------|-----------|-----------|-------|
-| **zipline_strict** | 226,723 | 226,723 | **0 (0.00%)** | $19 (0.0001%) | **8.4x faster** |
-| **backtrader_strict** | 216,980 | 216,981 | 1 (0.0005%) | $503 (0.004%) | **19.3x faster** |
+| **zipline_strict** | 226,723 | 226,723 | **0 (0.00%)** | $10.30 (0.0014%) | **8.0x faster** |
+| **backtrader_strict** | 226,535 | 226,535 | **0 (0.00%)** | ~$0 (float noise) | **7.7x faster** |
 | **vectorbt_strict** | 210,352 | 210,261 | 91 (0.04%) | $0 (0.00%) | 0.04x |
-| **lean_strict** | 226,246 | 225,583 | 663 (0.29%) | $13,150 (1.2%) | **5.3x faster** |
+| **lean** | 428,459 fills | 428,459 fills | **0 (0.00%)** | $1.55 (0.0002%) | **3.4x faster** |
 
 ## How to Run
 
@@ -142,7 +142,7 @@ validation/
 
 | Profile | Gap | Root Cause | Next Step |
 |---------|-----|------------|-----------|
-| zipline_strict | 0 trades, $19 | Floating point | **DONE** |
-| backtrader_strict | 1 trade, $503 | Unknown | Per-bar investigation |
+| zipline_strict | 0 trades, $10.30 | Small terminal-value residual | **DONE** |
+| backtrader_strict | 0 trades, float noise | Floating point | **DONE** |
 | vectorbt_strict | 91 trades, $0 | Unknown | Signal processing audit |
-| lean_strict | 663 trades, $13K | Buying-power reservation | Add `buying_power_reservation` knob |
+| lean | 0 fills, $1.55 | Price precision / mark-to-market rounding | **DONE** |

--- a/validation/benchmark_suite.py
+++ b/validation/benchmark_suite.py
@@ -40,12 +40,9 @@ import hashlib
 import json
 import os
 import pickle
-import shutil
-import subprocess
 import sys
 import time
 import tracemalloc
-import zipfile
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -58,6 +55,51 @@ import pandas as pd
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
+from ml4t.backtest._validation.backtrader_runner import load_backtrader_package  # noqa: E402
+from ml4t.backtest._validation.backtrader_runner import (  # noqa: E402
+    run_backtrader_target_shares as shared_run_backtrader_target_shares,
+)
+from ml4t.backtest._validation.lean_runner import (  # noqa: E402
+    build_sequential_ticker_map,
+    check_lean_cli,
+    copy_lean_artifacts,
+    encode_sequential_ticker,
+    export_lean_daily_data,
+    make_lean_env,
+    resolve_lean_command,
+    run_lean_backtest,
+)
+from ml4t.backtest._validation.lean_runner import (  # noqa: E402
+    load_lean_artifacts as shared_load_lean_artifacts,
+)
+from ml4t.backtest._validation.lean_runner import (  # noqa: E402
+    load_lean_symbol_map as shared_load_lean_symbol_map,
+)
+from ml4t.backtest._validation.lean_runner import (  # noqa: E402
+    parse_lean_float as shared_parse_lean_float,
+)
+from ml4t.backtest._validation.lean_runner import (  # noqa: E402
+    parse_lean_int as shared_parse_lean_int,
+)
+from ml4t.backtest._validation.lean_runner import (  # noqa: E402
+    read_lean_csv as shared_read_lean_csv,
+)
+from ml4t.backtest._validation.vectorbt_runner import (  # noqa: E402
+    extract_trade_log as shared_extract_vectorbt_trade_log,
+)
+from ml4t.backtest._validation.vectorbt_runner import (  # noqa: E402
+    get_equity_curve as shared_get_vectorbt_equity_curve,
+)
+from ml4t.backtest._validation.vectorbt_runner import (  # noqa: E402
+    load_vectorbt_package,
+)
+from ml4t.backtest._validation.vectorbt_runner import (  # noqa: E402
+    run_vectorbt_orders as shared_run_vectorbt_orders,
+)
+from ml4t.backtest._validation.zipline_runner import load_zipline_modules  # noqa: E402
+from ml4t.backtest._validation.zipline_runner import (  # noqa: E402
+    run_zipline_target_shares as shared_run_zipline_target_shares,
+)
 
 _BENCHMARK_LOG_FILE = os.getenv("ML4T_BENCHMARK_LOG_FILE")
 DEFAULT_REAL_DATA_PATH = Path("/home/stefan/Dropbox/ml4t/data/equities/us_equities.parquet")
@@ -87,7 +129,9 @@ def _to_naive_date(ts_like: pd.Timestamp | datetime | str) -> pd.Timestamp:
     return ts.normalize()
 
 
-def _get_nyse_sessions(start_date: pd.Timestamp | datetime | str, end_date: pd.Timestamp | datetime | str) -> pd.DatetimeIndex:
+def _get_nyse_sessions(
+    start_date: pd.Timestamp | datetime | str, end_date: pd.Timestamp | datetime | str
+) -> pd.DatetimeIndex:
     start = _to_naive_date(start_date)
     end = _to_naive_date(end_date)
     if start > end:
@@ -119,7 +163,9 @@ def _get_nyse_sessions(start_date: pd.Timestamp | datetime | str, end_date: pd.T
     return pd.bdate_range(start=start, end=end)
 
 
-def _get_trailing_nyse_sessions(n_bars: int, end_date: pd.Timestamp | datetime | str | None = None) -> pd.DatetimeIndex:
+def _get_trailing_nyse_sessions(
+    n_bars: int, end_date: pd.Timestamp | datetime | str | None = None
+) -> pd.DatetimeIndex:
     if n_bars <= 0:
         return pd.DatetimeIndex([], dtype="datetime64[ns]")
 
@@ -511,7 +557,7 @@ def load_real_benchmark_data(
         raise ValueError(
             f"Requested {config.n_bars} bars, but real dataset only has {len(session_dates)} sessions"
         )
-    dates = session_dates[-config.n_bars:]
+    dates = session_dates[-config.n_bars :]
 
     window = raw[raw["date"].isin(dates)].copy()
     counts = window.groupby("ticker")["date"].nunique().sort_values(ascending=False)
@@ -617,7 +663,9 @@ def build_canonical_target_shares(
     return target_shares
 
 
-def build_canonical_target_lookup(target_shares: pd.DataFrame) -> dict[pd.Timestamp, dict[str, float]]:
+def build_canonical_target_lookup(
+    target_shares: pd.DataFrame,
+) -> dict[pd.Timestamp, dict[str, float]]:
     """Build sparse timestamp -> non-zero target map."""
     target_lookup: dict[pd.Timestamp, dict[str, float]] = {}
     values = target_shares.to_numpy()
@@ -645,7 +693,9 @@ def build_canonical_target_trace(target_shares: pd.DataFrame) -> pd.DataFrame:
     trace_delta = delta.where(changed).stack()
 
     if len(trace_targets) == 0:
-        return pd.DataFrame(columns=["timestamp", "asset", "prev_target", "target", "delta", "action"])
+        return pd.DataFrame(
+            columns=["timestamp", "asset", "prev_target", "target", "delta", "action"]
+        )
 
     trace = pd.DataFrame(
         {
@@ -683,6 +733,8 @@ class BenchmarkResult:
     memory_mb: float
     error: str | None = None
     trades_df: pd.DataFrame | None = None  # Trade log for validation
+    equity_df: pd.DataFrame | None = None  # Equity curve for validation
+    order_events_df: pd.DataFrame | None = None  # Raw order-event log for debugging
     positions_df: pd.DataFrame | None = None  # PyFolio positions (Backtrader/Zipline)
     transactions_df: pd.DataFrame | None = None  # PyFolio transactions (Backtrader/Zipline)
     target_trace_df: pd.DataFrame | None = None  # Canonical target-change trace
@@ -752,8 +804,8 @@ def generate_json_report(
         },
         "results": [r.to_dict() for r in results],
         "summary": {
-            "total_scenarios": len(set(r.scenario for r in results)),
-            "total_frameworks": len(set(r.framework for r in results)),
+            "total_scenarios": len({r.scenario for r in results}),
+            "total_frameworks": len({r.framework for r in results}),
             "errors": sum(1 for r in results if r.error),
         },
     }
@@ -781,8 +833,8 @@ def generate_markdown_report(
         "",
         "## Summary",
         "",
-        f"- Total scenarios: {len(set(r.scenario for r in results))}",
-        f"- Frameworks tested: {', '.join(sorted(set(r.framework for r in results)))}",
+        f"- Total scenarios: {len({r.scenario for r in results})}",
+        f"- Frameworks tested: {', '.join(sorted({r.framework for r in results}))}",
         f"- Errors: {sum(1 for r in results if r.error)}",
         "",
         "## Results by Scenario",
@@ -822,7 +874,7 @@ def generate_markdown_report(
         lines.append("")
 
     # Performance comparison if multiple frameworks
-    frameworks = sorted(set(r.framework for r in results if not r.error))
+    frameworks = sorted({r.framework for r in results if not r.error})
     if len(frameworks) > 1:
         lines.extend(
             [
@@ -914,7 +966,9 @@ def benchmark_ml4t(
     # Select profile by execution style
     default_profile = "backtrader" if execution_mode == "next_bar" else "vectorbt"
     profile_name = profile_override or default_profile
-    framework_name = "ml4t.backtest" if execution_mode == "same_bar" else "ml4t.backtest (backtrader-mode)"
+    framework_name = (
+        "ml4t.backtest" if execution_mode == "same_bar" else "ml4t.backtest (backtrader-mode)"
+    )
     if profile_override is not None:
         framework_name = f"ml4t.backtest[{profile_name}]"
 
@@ -1088,9 +1142,24 @@ def benchmark_ml4t(
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
 
-    # Extract trade log for validation
+    # Extract validation surface. For LEAN parity we need fill-level chronology,
+    # not round-trip trade summaries.
     trades_df = None
-    if results.get("trades"):
+    if profile_name == "lean":
+        fills_df = results.to_fills_dataframe().to_pandas()
+        if not fills_df.empty:
+            trades_df = fills_df.rename(
+                columns={
+                    "price": "fill_price",
+                    "commission": "fee",
+                }
+            )
+            if "quantity" in trades_df.columns:
+                trades_df["quantity"] = trades_df["quantity"].abs()
+            if "side" in trades_df.columns:
+                trades_df["side"] = trades_df["side"].astype(str).str.lower()
+            trades_df = trades_df.sort_values(["timestamp", "order_id"]).reset_index(drop=True)
+    elif results.get("trades"):
         trade_records = []
         for t in results["trades"]:
             trade_records.append(
@@ -1107,11 +1176,15 @@ def benchmark_ml4t(
             )
         trades_df = pd.DataFrame(trade_records)
 
+    trade_count = results["num_trades"]
+    if profile_name == "lean" and trades_df is not None:
+        trade_count = len(trades_df)
+
     return BenchmarkResult(
         framework=framework_name,
         scenario=config.name,
         runtime_sec=end_time - start_time,
-        num_trades=results["num_trades"],
+        num_trades=trade_count,
         final_value=results["final_value"],
         memory_mb=peak / 1024 / 1024,
         trades_df=trades_df,
@@ -1124,7 +1197,7 @@ def benchmark_vectorbt_pro(
 ) -> BenchmarkResult:
     """Benchmark VectorBT Pro with given configuration."""
     try:
-        import vectorbtpro as vbt
+        vbt = load_vectorbt_package("vectorbtpro")
     except ImportError:
         return BenchmarkResult(
             framework="VectorBT Pro",
@@ -1146,54 +1219,25 @@ def benchmark_vectorbt_pro(
     tracemalloc.start()
     start_time = time.perf_counter()
 
-    # Use from_orders with target shares
-    # cash_sharing=True ensures single cash pool across all assets (like real portfolio)
-    pf = vbt.Portfolio.from_orders(
+    pf = shared_run_vectorbt_orders(
+        vbt=vbt,
         close=close_df,
         size=target_shares,
         size_type="targetamount",
         init_cash=config.initial_cash,
-        cash_sharing=True,  # Critical: single cash pool, not per-column
+        cash_sharing=True,
         fees=config.commission_pct,
         slippage=config.slippage_pct,
-        # Note: VectorBT Pro doesn't have native stop-loss in from_orders
-        # Would need from_signals with sl_stop parameter
     )
 
-    # Force computation
-    final_value = (
-        pf.value.iloc[-1].sum() if hasattr(pf.value.iloc[-1], "sum") else pf.value.iloc[-1]
-    )
-    trades_readable = pf.trades.records_readable
-    num_trades = len(trades_readable)
+    equity = shared_get_vectorbt_equity_curve(pf)
+    final_value = float(equity.iloc[-1])
+    trades_df = shared_extract_vectorbt_trade_log(pf)
+    num_trades = len(trades_df)
 
     end_time = time.perf_counter()
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
-
-    # Extract trade log for validation
-    trades_df = None
-    if num_trades > 0:
-        # Sort by entry date for proper comparison (VBT returns sorted by column/asset)
-        trades_readable = trades_readable.sort_values("Entry Index")
-        trade_records = []
-        for _, row in trades_readable.iterrows():
-            # VectorBT Pro's Entry Index is already a Timestamp
-            entry_ts = row.get("Entry Index")
-            trade_records.append(
-                {
-                    "timestamp": entry_ts,
-                    "asset": row.get("Column", "unknown"),
-                    "side": "long"
-                    if str(row.get("Direction", "Long")).lower() == "long"
-                    else "short",
-                    "quantity": abs(row.get("Size", 0)),
-                    "entry_price": row.get("Avg Entry Price", 0),
-                    "exit_price": row.get("Avg Exit Price", 0),
-                    "pnl": row.get("PnL", 0),
-                }
-            )
-        trades_df = pd.DataFrame(trade_records)
 
     return BenchmarkResult(
         framework="VectorBT Pro",
@@ -1212,7 +1256,7 @@ def benchmark_vectorbt_oss(
 ) -> BenchmarkResult:
     """Benchmark VectorBT OSS with given configuration."""
     try:
-        import vectorbt as vbt
+        vbt = load_vectorbt_package("vectorbt")
     except ImportError:
         return BenchmarkResult(
             framework="VectorBT OSS",
@@ -1234,53 +1278,26 @@ def benchmark_vectorbt_oss(
     tracemalloc.start()
     start_time = time.perf_counter()
 
-    # VectorBT OSS uses from_orders API
-    # cash_sharing=True ensures single cash pool across all assets (like real portfolio)
-    # lock_cash=True enforces cash constraints on short selling (default is False in OSS!)
-    pf = vbt.Portfolio.from_orders(
+    pf = shared_run_vectorbt_orders(
+        vbt=vbt,
         close=close_df,
         size=target_shares,
         size_type="targetamount",
         init_cash=config.initial_cash,
-        cash_sharing=True,  # Critical: single cash pool, not per-column
-        lock_cash=True,  # Critical: enforce cash constraints (VBT OSS default is False!)
+        cash_sharing=True,
+        lock_cash=True,
         fees=config.commission_pct,
         slippage=config.slippage_pct,
     )
 
-    # Force computation
-    final_value = (
-        pf.value().iloc[-1].sum() if hasattr(pf.value().iloc[-1], "sum") else pf.value().iloc[-1]
-    )
-    trades_readable = pf.trades.records_readable
-    num_trades = len(trades_readable)
+    equity = shared_get_vectorbt_equity_curve(pf)
+    final_value = float(equity.iloc[-1])
+    trades_df = shared_extract_vectorbt_trade_log(pf)
+    num_trades = len(trades_df)
 
     end_time = time.perf_counter()
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
-
-    # Extract trade log for validation
-    trades_df = None
-    if num_trades > 0:
-        # Sort by entry date for proper comparison (VBT returns sorted by column/asset)
-        entry_col = (
-            "Entry Timestamp" if "Entry Timestamp" in trades_readable.columns else "Entry Index"
-        )
-        trades_readable = trades_readable.sort_values(entry_col)
-        trade_records = []
-        for _, row in trades_readable.iterrows():
-            trade_records.append(
-                {
-                    "timestamp": row.get("Entry Timestamp", row.get("Entry Index")),
-                    "asset": row.get("Column", "unknown"),
-                    "side": "long" if row.get("Direction", "Long") == "Long" else "short",
-                    "quantity": abs(row.get("Size", 0)),
-                    "entry_price": row.get("Avg Entry Price", row.get("Entry Price", 0)),
-                    "exit_price": row.get("Avg Exit Price", row.get("Exit Price", 0)),
-                    "pnl": row.get("PnL", 0),
-                }
-            )
-        trades_df = pd.DataFrame(trade_records)
 
     return BenchmarkResult(
         framework="VectorBT OSS",
@@ -1303,19 +1320,7 @@ def benchmark_zipline(
     top-N/bottom-N ranking strategy.
     """
     try:
-        from zipline import run_algorithm
-        from zipline.api import (
-            get_datetime,
-            order_target,
-            set_commission,
-            set_max_leverage,
-            set_slippage,
-            sid,
-        )
-        from zipline.data.bundles import ingest, register
-        from zipline.finance.commission import NoCommission, PerDollar
-        from zipline.finance.slippage import SlippageModel
-        from zipline.utils.calendar_utils import get_calendar as zipline_get_calendar
+        zipline_modules = load_zipline_modules()
     except ImportError as e:
         return BenchmarkResult(
             framework="Zipline",
@@ -1339,335 +1344,41 @@ def benchmark_zipline(
             error="Zipline bundles only support daily data",
         )
 
-    # Get NYSE calendar sessions for proper date alignment
-    nyse = zipline_get_calendar("XNYS")
-
-    # Prepare all assets for the bundle
     asset_names = sorted(price_data.keys())
-    n_assets = len(asset_names)
-    target_shares = build_canonical_target_shares(config, signals, pd.DatetimeIndex(dates), asset_names)
+    target_shares = build_canonical_target_shares(
+        config, signals, pd.DatetimeIndex(dates), asset_names
+    )
     target_trace = build_canonical_target_trace(target_shares)
     target_lookup_raw = build_canonical_target_lookup(target_shares)
-    target_lookup: dict[pd.Timestamp, dict[str, float]] = {}
-    for ts, targets in target_lookup_raw.items():
-        ts_naive = ts.tz_convert(None) if ts.tz is not None else ts
-        target_lookup[pd.Timestamp(ts_naive).normalize()] = targets
-
-    # Convert price data to have NYSE-aligned dates
-    # Filter to only NYSE trading days
-    first_df = price_data[asset_names[0]]
-    start_date = first_df.index[0]
-    end_date = first_df.index[-1]
-
-    # Get actual NYSE sessions
-    nyse_sessions = nyse.sessions_in_range(
-        pd.Timestamp(start_date).tz_localize(None) if pd.Timestamp(start_date).tz else start_date,
-        pd.Timestamp(end_date).tz_localize(None) if pd.Timestamp(end_date).tz else end_date,
-    )
-
-    # Custom slippage model for open-price fills (matching ml4t NEXT_BAR mode)
-    class OpenPriceSlippage(SlippageModel):
-        @staticmethod
-        def process_order(data, order):
-            open_px = data.current(order.asset, "open")
-            if config.slippage_pct > 0:
-                if order.amount > 0:
-                    open_px = open_px * (1.0 + config.slippage_pct)
-                elif order.amount < 0:
-                    open_px = open_px * (1.0 - config.slippage_pct)
-            return (open_px, order.amount)
-
-    # Bundle ingest function for multi-asset
-    def make_multi_asset_ingest(price_data_dict, asset_list):
-        def ingest_func(
-            environ,
-            asset_db_writer,
-            minute_bar_writer,
-            daily_bar_writer,
-            adjustment_writer,
-            calendar,
-            start_session,
-            end_session,
-            cache,
-            show_progress,
-            output_dir,
-        ):
-            sessions = calendar.sessions_in_range(start_session, end_session)
-            sessions = pd.DatetimeIndex(sessions).tz_localize(None)
-
-            # Write equity metadata for all assets
-            equities_df = pd.DataFrame(
-                {
-                    "symbol": asset_list,
-                    "asset_name": [f"Asset {name}" for name in asset_list],
-                    "exchange": ["NYSE"] * len(asset_list),
-                }
-            )
-            asset_db_writer.write(equities=equities_df)
-
-            # Write daily bars for each asset
-            bar_data = []
-            for sid, asset_name in enumerate(asset_list):
-                df = price_data_dict[asset_name].copy()
-                # Convert to tz-naive
-                if df.index.tz is not None:
-                    df.index = df.index.tz_convert(None)
-                # Align explicitly to session index to satisfy Zipline writer invariants.
-                trading_df = df.reindex(sessions).ffill().bfill()[["open", "high", "low", "close", "volume"]]
-                if len(trading_df) > 0:
-                    bar_data.append((sid, trading_df))
-
-            daily_bar_writer.write(bar_data, show_progress=show_progress)
-            adjustment_writer.write()
-
-        return ingest_func
-
-    # Register and ingest bundle (cached - only created once per config)
-    import hashlib
-
-    bundle_sig_input = "|".join(asset_names) + f"|{pd.Timestamp(dates[0]).date()}|{pd.Timestamp(dates[-1]).date()}"
-    bundle_sig = hashlib.md5(bundle_sig_input.encode("utf-8")).hexdigest()[:10]
-    bundle_name = f"bench_multi_{n_assets}_{config.n_bars}_{bundle_sig}"
-    start_session = nyse_sessions[0]
-    end_session = (
-        nyse_sessions[-1]
-        if len(nyse_sessions) <= config.n_bars
-        else nyse_sessions[config.n_bars - 1]
-    )
-
-    # Check if bundle already exists ON DISK to avoid re-ingestion
-    # The in-memory `bundles` registry resets each process - check filesystem instead
-    import os
-    from pathlib import Path
-
-    zipline_root = Path(os.environ.get("ZIPLINE_ROOT", Path.home() / ".zipline"))
-    bundle_dir = zipline_root / "data" / bundle_name  # Zipline stores in data/, not bundles/
-    bundle_exists = False
-    if bundle_dir.exists() and any(bundle_dir.iterdir()):
-        bundle_runs = sorted(p for p in bundle_dir.iterdir() if p.is_dir())
-        if bundle_runs:
-            latest_run = bundle_runs[-1]
-            assets_ok = any(latest_run.glob("assets-*.sqlite"))
-            if assets_ok:
-                bundle_exists = True
-            else:
-                shutil.rmtree(bundle_dir, ignore_errors=True)
-
-    bundle_time = 0.0
-    if not bundle_exists:
-        bundle_start = time.perf_counter()
-        try:
-            register(
-                bundle_name,
-                make_multi_asset_ingest(price_data, asset_names),
-                calendar_name="XNYS",
-                start_session=start_session,
-                end_session=end_session,
-            )
-            ingest(bundle_name, show_progress=False)
-            bundle_time = time.perf_counter() - bundle_start
-            _log(f"  Bundle creation: {bundle_time:.1f}s (one-time setup)")
-        except Exception as e:
-            return BenchmarkResult(
-                framework="Zipline",
-                scenario=config.name,
-                runtime_sec=0,
-                num_trades=0,
-                final_value=0,
-                memory_mb=0,
-                error=f"Bundle setup failed: {e}",
-            )
-    else:
-        # Bundle exists on disk - just re-register (required for run_algorithm in this process)
-        _log(f"  Using cached bundle: {bundle_name}")
-        register(
-            bundle_name,
-            make_multi_asset_ingest(price_data, asset_names),
-            calendar_name="XNYS",
-            start_session=start_session,
-            end_session=end_session,
-        )
-
-    # Algorithm state
-    algo_state = {
-        "target_lookup": target_lookup,
-        "asset_names": asset_names,
-    }
-
-    def initialize(context):
-        context.state = algo_state
-        # Get all asset objects by sid
-        context.assets = [sid(i) for i in range(len(context.state["asset_names"]))]
-        context.asset_map = {
-            name: context.assets[i] for i, name in enumerate(context.state["asset_names"])
-        }
-        context.name_by_asset = {asset: name for name, asset in context.asset_map.items()}
-        if config.commission_pct > 0:
-            set_commission(PerDollar(cost=config.commission_pct))
-        else:
-            set_commission(NoCommission())
-        if config.zipline_max_leverage is not None:
-            set_max_leverage(config.zipline_max_leverage)
-        set_slippage(OpenPriceSlippage())
-
-    def handle_data(context, data):
-        dt = get_datetime()
-        # Normalize datetime for lookup
-        dt_naive = dt.tz_convert(None) if dt.tz else dt
-        dt_normalized = dt_naive.normalize()
-
-        targets = context.state["target_lookup"].get(dt_normalized, {})
-        active_names = set(targets.keys())
-        for asset_obj, position in context.portfolio.positions.items():
-            if position.amount != 0:
-                asset_name = context.name_by_asset.get(asset_obj)
-                if asset_name is not None:
-                    active_names.add(asset_name)
-
-        for asset_name in sorted(active_names):
-            asset = context.asset_map[asset_name]
-            if not data.can_trade(asset):
-                continue
-
-            current_pos = context.portfolio.positions[asset].amount
-            target = targets.get(asset_name, 0.0)
-            if current_pos != target:
-                order_target(asset, target)
-
     gc.collect()
     tracemalloc.start()
     start_time = time.perf_counter()
 
     try:
-        results = run_algorithm(
-            start=start_session,
-            end=end_session,
-            initialize=initialize,
-            handle_data=handle_data,
-            capital_base=config.initial_cash,
-            bundle=bundle_name,
-            data_frequency="daily",
+        run_result = shared_run_zipline_target_shares(
+            modules=zipline_modules,
+            config=config,
+            price_data=price_data,
+            dates=pd.DatetimeIndex(dates),
+            target_lookup_raw=target_lookup_raw,
+            logger=_log,
         )
-
-        final_value = results["portfolio_value"].iloc[-1]
-
         end_time = time.perf_counter()
         _, peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
-
-        def flatten_column(column_name: str) -> pd.DataFrame:
-            records = []
-            if column_name not in results.columns:
-                return pd.DataFrame()
-            for dt, payload in results[column_name].items():
-                if not isinstance(payload, list):
-                    continue
-                for item in payload:
-                    if isinstance(item, dict):
-                        record = dict(item)
-                    elif hasattr(item, "to_dict"):
-                        record = item.to_dict()
-                    elif hasattr(item, "items"):
-                        record = dict(item.items())
-                    else:
-                        continue
-                    record["dt"] = dt
-                    records.append(record)
-            return pd.DataFrame(records)
-
-        positions = flatten_column("positions")
-        transactions = flatten_column("transactions")
-        orders = flatten_column("orders")
-
-        trades_df = None
-        trade_records = []
-
-        if not transactions.empty:
-            transactions = transactions.copy()
-            transactions["dt"] = pd.to_datetime(transactions["dt"])
-            amount_col = "amount" if "amount" in transactions.columns else "filled"
-            price_col = "price" if "price" in transactions.columns else "last_sale_price"
-            symbol_col = (
-                "symbol"
-                if "symbol" in transactions.columns
-                else "sid"
-                if "sid" in transactions.columns
-                else "asset"
-                if "asset" in transactions.columns
-                else None
-            )
-
-            if symbol_col and amount_col in transactions.columns and price_col in transactions.columns:
-                for symbol in transactions[symbol_col].dropna().unique():
-                    symbol_txns = transactions[transactions[symbol_col] == symbol].sort_values("dt")
-
-                    running_pos = 0.0
-                    entry_time = None
-                    entry_price = None
-                    entry_size = 0.0
-
-                    for _, row in symbol_txns.iterrows():
-                        amount = float(row[amount_col])
-                        price = float(row[price_col])
-                        prev_pos = running_pos
-                        running_pos += amount
-
-                        if prev_pos == 0 and running_pos != 0:
-                            entry_time = row["dt"]
-                            entry_price = price
-                            entry_size = amount
-                        elif prev_pos != 0 and running_pos == 0:
-                            exit_price = price
-                            pnl = (exit_price - entry_price) * entry_size
-                            trade_records.append(
-                                {
-                                    "entry_date": entry_time,
-                                    "exit_date": row["dt"],
-                                    "asset": str(symbol),
-                                    "side": "long" if entry_size > 0 else "short",
-                                    "quantity": abs(entry_size),
-                                    "entry_price": entry_price,
-                                    "exit_price": exit_price,
-                                    "pnl": pnl,
-                                }
-                            )
-                            entry_time = None
-                        elif prev_pos != 0 and running_pos != 0 and (prev_pos > 0) != (running_pos > 0):
-                            exit_price = price
-                            pnl = (exit_price - entry_price) * entry_size
-                            trade_records.append(
-                                {
-                                    "entry_date": entry_time,
-                                    "exit_date": row["dt"],
-                                    "asset": str(symbol),
-                                    "side": "long" if entry_size > 0 else "short",
-                                    "quantity": abs(entry_size),
-                                    "entry_price": entry_price,
-                                    "exit_price": exit_price,
-                                    "pnl": pnl,
-                                }
-                            )
-                            entry_time = row["dt"]
-                            entry_price = price
-                            entry_size = running_pos
-
-        num_trades = len(trade_records)
-        if num_trades == 0:
-            num_trades = int(len(orders)) if not orders.empty else 0
-        if trade_records:
-            trades_df = pd.DataFrame(trade_records).sort_values("entry_date")
 
         return BenchmarkResult(
             framework="Zipline",
             scenario=config.name,
             runtime_sec=end_time - start_time,
-            num_trades=num_trades,
-            final_value=float(final_value),
+            num_trades=run_result.num_trades,
+            final_value=run_result.final_value,
             memory_mb=peak / 1024 / 1024,
-            trades_df=trades_df,
-            positions_df=positions if not positions.empty else None,
-            transactions_df=transactions if not transactions.empty else None,
+            trades_df=run_result.trades_df,
+            positions_df=run_result.positions_df,
+            transactions_df=run_result.transactions_df,
             target_trace_df=target_trace,
+            setup_time_sec=run_result.setup_time_sec,
         )
     except Exception as e:
         tracemalloc.stop()
@@ -1694,7 +1405,7 @@ def benchmark_backtrader(
 ) -> BenchmarkResult:
     """Benchmark Backtrader with given configuration."""
     try:
-        import backtrader as bt
+        bt = load_backtrader_package()
     except ImportError:
         return BenchmarkResult(
             framework="Backtrader",
@@ -1707,150 +1418,39 @@ def benchmark_backtrader(
         )
 
     asset_names = sorted(price_data.keys())
-    target_shares = build_canonical_target_shares(config, signals, pd.DatetimeIndex(dates), asset_names)
+    target_shares = build_canonical_target_shares(
+        config, signals, pd.DatetimeIndex(dates), asset_names
+    )
     target_trace = build_canonical_target_trace(target_shares)
     target_lookup_raw = build_canonical_target_lookup(target_shares)
     target_lookup = {ts.strftime("%Y-%m-%d"): targets for ts, targets in target_lookup_raw.items()}
-
-    class TopBottomBTStrategy(bt.Strategy):
-        def __init__(self):
-            self.target_lookup = target_lookup
-            self.data_by_name = {d._name: d for d in self.datas}
-
-        def next(self):
-            dt = self.datas[0].datetime.datetime(0)
-            dt_key = dt.strftime("%Y-%m-%d")
-            targets = self.target_lookup.get(dt_key, {})
-
-            active_names = set(targets.keys())
-            for data in self.datas:
-                if self.getposition(data).size != 0:
-                    active_names.add(data._name)
-
-            for asset_name in sorted(active_names):
-                data = self.data_by_name[asset_name]
-                current_size = self.getposition(data).size
-                target_size = targets.get(asset_name, 0.0)
-                if current_size != target_size:
-                    self.order_target_size(data=data, target=target_size)
-
-    cerebro = bt.Cerebro()
-    cerebro.addstrategy(TopBottomBTStrategy)
-
-    # Add data feeds
-    for asset_name, df in price_data.items():
-        data = bt.feeds.PandasData(dataname=df, name=asset_name)
-        cerebro.adddata(data)
-
-    # Align capital base with other frameworks for apples-to-apples comparison
-    cerebro.broker.setcash(config.initial_cash)
-
-    if config.commission_pct > 0:
-        cerebro.broker.setcommission(commission=config.commission_pct)
-
-    # Add PyFolio analyzer to get standardized positions/transactions output
-    cerebro.addanalyzer(bt.analyzers.PyFolio, _name="pyfolio")
 
     gc.collect()
     tracemalloc.start()
     start_time = time.perf_counter()
 
-    results = cerebro.run()
-    final_value = cerebro.broker.getvalue()
+    run_result = shared_run_backtrader_target_shares(
+        bt=bt,
+        price_data=price_data,
+        target_lookup=target_lookup,
+        initial_cash=config.initial_cash,
+        commission_pct=config.commission_pct,
+    )
 
     end_time = time.perf_counter()
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
 
-    # Extract positions and transactions via PyFolio analyzer
-    strat = results[0]
-    pyfolio_analyzer = strat.analyzers.getbyname("pyfolio")
-    returns, positions, transactions, gross_lev = pyfolio_analyzer.get_pf_items()
-
-    # Convert transactions to completed trades by tracking position changes
-    # transactions format: index=datetime, columns=[amount, price, sid, symbol, value]
-    # A trade completes when position goes to 0 or flips sign
-    trades_df = None
-    trade_records = []
-
-    # Group transactions by symbol and process sequentially
-    if len(transactions) > 0 and "symbol" in transactions.columns:
-        for symbol in transactions["symbol"].unique():
-            symbol_txns = transactions[transactions["symbol"] == symbol].sort_index()
-
-            running_pos = 0
-            entry_time = None
-            entry_price = None
-            entry_size = 0
-
-            for dt, row in symbol_txns.iterrows():
-                amount = row["amount"]
-                price = row["price"]
-                prev_pos = running_pos
-                running_pos += amount
-
-                # Check if position just opened
-                if prev_pos == 0 and running_pos != 0:
-                    entry_time = dt
-                    entry_price = price
-                    entry_size = amount
-
-                # Check if position just closed (or flipped)
-                elif prev_pos != 0 and running_pos == 0:
-                    # Position closed completely
-                    exit_price = price
-                    pnl = (exit_price - entry_price) * entry_size
-                    trade_records.append(
-                        {
-                            "entry_date": entry_time,
-                            "exit_date": dt,
-                            "asset": str(symbol),
-                            "side": "long" if entry_size > 0 else "short",
-                            "quantity": abs(entry_size),
-                            "entry_price": entry_price,
-                            "exit_price": exit_price,
-                            "pnl": pnl,
-                        }
-                    )
-                    entry_time = None
-
-                # Handle position flip (e.g., long -> short or short -> long)
-                elif prev_pos != 0 and running_pos != 0 and (prev_pos > 0) != (running_pos > 0):
-                    # Close old position first
-                    exit_price = price
-                    pnl = (exit_price - entry_price) * entry_size
-                    trade_records.append(
-                        {
-                            "entry_date": entry_time,
-                            "exit_date": dt,
-                            "asset": str(symbol),
-                            "side": "long" if entry_size > 0 else "short",
-                            "quantity": abs(entry_size),
-                            "entry_price": entry_price,
-                            "exit_price": exit_price,
-                            "pnl": pnl,
-                        }
-                    )
-                    # Open new position
-                    entry_time = dt
-                    entry_price = price
-                    entry_size = running_pos
-
-    num_trades = len(trade_records)
-    if trade_records:
-        trades_df = pd.DataFrame(trade_records)
-        trades_df = trades_df.sort_values("entry_date")
-
     return BenchmarkResult(
         framework="Backtrader",
         scenario=config.name,
         runtime_sec=end_time - start_time,
-        num_trades=num_trades,
-        final_value=final_value,
+        num_trades=run_result.num_trades,
+        final_value=run_result.final_value,
         memory_mb=peak / 1024 / 1024,
-        trades_df=trades_df,
-        positions_df=positions,
-        transactions_df=transactions,
+        trades_df=run_result.trades_df,
+        positions_df=run_result.positions_df,
+        transactions_df=run_result.transactions_df,
         target_trace_df=target_trace,
     )
 
@@ -1919,7 +1519,9 @@ def benchmark_nautilus(
     progress_every_bars = max(0, int(os.getenv("ML4T_NAUTILUS_PROGRESS_EVERY_BARS", "50000")))
     processed_bars = {"count": 0}
 
-    target_shares = build_canonical_target_shares(config, signals, pd.DatetimeIndex(dates), asset_names)
+    target_shares = build_canonical_target_shares(
+        config, signals, pd.DatetimeIndex(dates), asset_names
+    )
     target_trace = build_canonical_target_trace(target_shares)
     target_lookup = build_canonical_target_lookup(target_shares)
     target_lookup_str = {ts.strftime("%Y-%m-%d"): targets for ts, targets in target_lookup.items()}
@@ -2017,7 +1619,9 @@ def benchmark_nautilus(
             bars: list[Bar] = []
             for ts, row in price_data[asset_name].sort_index().iterrows():
                 ts_utc = pd.Timestamp(ts)
-                ts_utc = ts_utc.tz_localize("UTC") if ts_utc.tz is None else ts_utc.tz_convert("UTC")
+                ts_utc = (
+                    ts_utc.tz_localize("UTC") if ts_utc.tz is None else ts_utc.tz_convert("UTC")
+                )
                 ts_ns = dt_to_unix_nanos(ts_utc.to_pydatetime())
                 bars.append(
                     Bar(
@@ -2057,7 +1661,9 @@ def benchmark_nautilus(
         fills_report = engine.trader.generate_order_fills_report()
         account_report = engine.trader.generate_account_report(venue)
         fills_df = fills_report.copy() if isinstance(fills_report, pd.DataFrame) else pd.DataFrame()
-        account_df = account_report.copy() if isinstance(account_report, pd.DataFrame) else pd.DataFrame()
+        account_df = (
+            account_report.copy() if isinstance(account_report, pd.DataFrame) else pd.DataFrame()
+        )
 
         final_value = float(config.initial_cash)
         if not account_df.empty:
@@ -2102,6 +1708,32 @@ def benchmark_nautilus(
             engine.dispose()
 
 
+def _parse_lean_int(value: object) -> int:
+    return shared_parse_lean_int(value)
+
+
+def _parse_lean_float(value: object) -> float:
+    return shared_parse_lean_float(value)
+
+
+def _encode_lean_ticker(idx: int) -> str:
+    return encode_sequential_ticker(idx)
+
+
+def _load_lean_symbol_map(output_dir: Path) -> dict[str, str]:
+    return shared_load_lean_symbol_map(output_dir)
+
+
+def _read_lean_csv(path: Path, parse_dates: list[str] | None = None) -> pd.DataFrame | None:
+    return shared_read_lean_csv(path, parse_dates=parse_dates)
+
+
+def _load_lean_artifacts(
+    output_dir: Path,
+) -> tuple[int, float, pd.DataFrame | None, pd.DataFrame | None, pd.DataFrame | None]:
+    return shared_load_lean_artifacts(output_dir)
+
+
 def benchmark_lean(
     config: BenchmarkConfig, price_data: dict, signals: pd.DataFrame, dates
 ) -> BenchmarkResult:
@@ -2130,59 +1762,23 @@ def benchmark_lean(
             error=f"LEAN config not found: {lean_config}",
         )
 
-    lean_binary = shutil.which("lean")
-    if lean_binary is not None:
-        lean_cmd = [lean_binary]
-    else:
-        uvx_binary = shutil.which("uvx")
-        if uvx_binary is None:
-            return BenchmarkResult(
-                framework="LEAN CLI",
-                scenario=config.name,
-                runtime_sec=0,
-                num_trades=0,
-                final_value=0,
-                memory_mb=0,
-                error="Neither 'lean' nor 'uvx' executable found",
-            )
-        lean_cmd = [uvx_binary, "--python", "3.12", "--with", "setuptools<81", "lean"]
-
-    def parse_int(value: object) -> int:
-        if value is None:
-            return 0
-        text = str(value).replace(",", "").strip()
-        if not text:
-            return 0
-        token = text.split()[0]
-        try:
-            return int(float(token))
-        except ValueError:
-            return 0
-
-    def parse_float(value: object) -> float:
-        if value is None:
-            return 0.0
-        text = str(value).replace(",", "").replace("$", "").replace("%", "").strip()
-        if not text:
-            return 0.0
-        token = text.split()[0]
-        try:
-            return float(token)
-        except ValueError:
-            return 0.0
-
-    def encode_ticker(idx: int) -> str:
-        letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        val = idx
-        chars: list[str] = []
-        for _ in range(4):
-            chars.append(letters[val % 26])
-            val //= 26
-        return "".join(reversed(chars))
+    try:
+        lean_cmd = resolve_lean_command()
+    except FileNotFoundError as exc:
+        return BenchmarkResult(
+            framework="LEAN CLI",
+            scenario=config.name,
+            runtime_sec=0,
+            num_trades=0,
+            final_value=0,
+            memory_mb=0,
+            error=str(exc),
+        )
 
     asset_names = sorted(price_data.keys())
-    asset_to_ticker = {asset_name: encode_ticker(i) for i, asset_name in enumerate(asset_names)}
+    asset_to_ticker = build_sequential_ticker_map(asset_names)
     tickers = [asset_to_ticker[asset_name] for asset_name in asset_names]
+    ticker_to_asset = {ticker: asset for asset, ticker in asset_to_ticker.items()}
 
     if config.lean_order_type not in {"market", "market_on_open"}:
         return BenchmarkResult(
@@ -2224,14 +1820,29 @@ def benchmark_lean(
         lean_account_stmt = "self.set_brokerage_model(BrokerageName.DEFAULT, AccountType.CASH)"
     elif config.lean_account_type == "margin":
         lean_account_stmt = "self.set_brokerage_model(BrokerageName.DEFAULT, AccountType.MARGIN)"
+    leverage_stmt = (
+        f"security.set_leverage({float(config.lean_security_leverage)})"
+        if config.lean_security_leverage is not None
+        else ""
+    )
+    zero_fee_stmt = "security.set_fee_model(ConstantFeeModel(0))" if force_zero_fee else ""
+    zero_slippage_stmt = (
+        "security.set_slippage_model(ConstantSlippageModel(0))" if force_zero_slippage else ""
+    )
 
-    target_shares = build_canonical_target_shares(config, signals, pd.DatetimeIndex(dates), asset_names)
+    target_shares = build_canonical_target_shares(
+        config, signals, pd.DatetimeIndex(dates), asset_names
+    )
     target_trace = build_canonical_target_trace(target_shares)
     target_shares_lean = target_shares.rename(columns=asset_to_ticker)
 
     project_dir = lean_workspace / "ml4t_benchmark"
     project_dir.mkdir(parents=True, exist_ok=True)
     (project_dir / "backtests").mkdir(parents=True, exist_ok=True)
+    for artifact_name in ("ml4t_daily_equity.csv", "ml4t_order_events.csv"):
+        artifact_path = project_dir / artifact_name
+        if artifact_path.exists():
+            artifact_path.unlink()
 
     config_json = {
         "algorithm-language": "Python",
@@ -2239,6 +1850,10 @@ def benchmark_lean(
         "description": "ml4t canonical target-share benchmark",
     }
     (project_dir / "config.json").write_text(json.dumps(config_json, indent=4), encoding="utf-8")
+    (project_dir / "ml4t_symbol_map.json").write_text(
+        json.dumps(ticker_to_asset, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
 
     symbols_path = project_dir / "symbols.csv"
     symbols_path.write_text("\n".join(tickers) + "\n", encoding="utf-8")
@@ -2268,6 +1883,9 @@ class Ml4tBenchmark(QCAlgorithm):
         {lean_account_stmt}
         self._targets = {{}}
         base_path = Path(__file__).resolve().parent
+        self._equity_path = base_path / "ml4t_daily_equity.csv"
+        self._order_events_path = base_path / "ml4t_order_events.csv"
+        self._initialize_artifact_files()
 
         with (base_path / "targets.csv").open(newline="") as f:
             reader = csv.DictReader(f)
@@ -2283,13 +1901,37 @@ class Ml4tBenchmark(QCAlgorithm):
             if not ticker:
                 continue
             security = self.add_equity(ticker, Resolution.DAILY)
-            {f"security.set_leverage({float(config.lean_security_leverage)})" if config.lean_security_leverage is not None else ""}
-            {"security.set_fee_model(ConstantFeeModel(0))" if force_zero_fee else ""}
-            {"security.set_slippage_model(ConstantSlippageModel(0))" if force_zero_slippage else ""}
+            {leverage_stmt}
+            {zero_fee_stmt}
+            {zero_slippage_stmt}
             self._symbols[ticker] = security.symbol
         if self._symbols:
             first_ticker = sorted(self._symbols.keys())[0]
             self.set_benchmark(self._symbols[first_ticker])
+
+    def _initialize_artifact_files(self):
+        with self._equity_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["timestamp", "equity", "cash", "total_fees", "holdings_value"])
+        with self._order_events_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    "timestamp",
+                    "symbol",
+                    "status",
+                    "direction",
+                    "fill_quantity",
+                    "fill_price",
+                    "fee",
+                    "message",
+                    "order_id",
+                ]
+            )
+
+    def _append_csv_row(self, path: Path, row: list[object]) -> None:
+        with path.open("a", newline="") as f:
+            csv.writer(f).writerow(row)
 
     def on_data(self, data: Slice):
         key = self.time.strftime("%Y-%m-%d")
@@ -2312,6 +1954,39 @@ class Ml4tBenchmark(QCAlgorithm):
             delta = int(round(target_qty - current_qty))
             if delta != 0:
                 {lean_order_call}
+
+        self._append_csv_row(
+            self._equity_path,
+            [
+                key,
+                float(self.portfolio.total_portfolio_value),
+                float(self.portfolio.cash),
+                float(self.portfolio.total_fees),
+                float(self.portfolio.total_holdings_value),
+            ],
+        )
+
+    def on_order_event(self, order_event: OrderEvent):
+        fee_amount = 0.0
+        if order_event.order_fee and order_event.order_fee.value is not None:
+            fee_amount = float(order_event.order_fee.value.amount)
+
+        message = str(order_event.message or "").replace("\\n", " ").strip()
+        symbol = order_event.symbol.value if order_event.symbol is not None else ""
+        self._append_csv_row(
+            self._order_events_path,
+            [
+                self.time.strftime("%Y-%m-%d %H:%M:%S"),
+                symbol,
+                str(order_event.status),
+                str(order_event.direction),
+                float(order_event.fill_quantity),
+                float(order_event.fill_price),
+                fee_amount,
+                message,
+                int(order_event.order_id),
+            ],
+        )
 """
     (project_dir / "main.py").write_text(main_code, encoding="utf-8")
 
@@ -2320,20 +1995,10 @@ class Ml4tBenchmark(QCAlgorithm):
     (data_root / "factor_files").mkdir(parents=True, exist_ok=True)
     (data_root / "daily").mkdir(parents=True, exist_ok=True)
 
-    env = os.environ.copy()
-    env.setdefault("UV_CACHE_DIR", "/tmp/uv-cache")
-    env.setdefault("UV_TOOL_DIR", "/tmp/uv-tools")
-
-    lean_check = subprocess.run(
-        lean_cmd + ["--version"],
-        cwd=str(PROJECT_ROOT),
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    if lean_check.returncode != 0:
-        error_text = (lean_check.stderr or lean_check.stdout).strip()
+    env = make_lean_env()
+    try:
+        check_lean_cli(lean_cmd, PROJECT_ROOT, env)
+    except RuntimeError as exc:
         return BenchmarkResult(
             framework="LEAN CLI",
             scenario=config.name,
@@ -2341,11 +2006,8 @@ class Ml4tBenchmark(QCAlgorithm):
             num_trades=0,
             final_value=0,
             memory_mb=0,
-            error=f"LEAN CLI unavailable: {error_text}",
+            error=str(exc),
         )
-
-    def scaled_price(value: float) -> int:
-        return int(round(float(value) * 10000.0))
 
     close_edge_sum = 0.0
     for asset_name in asset_names:
@@ -2368,55 +2030,18 @@ class Ml4tBenchmark(QCAlgorithm):
             cache_hit = False
 
     prep_start = time.perf_counter()
-    if not cache_hit:
-        for asset_name in asset_names:
-            ticker = asset_to_ticker[asset_name]
-            ticker_lower = ticker.lower()
-            asset_df = price_data[asset_name].sort_index()
-            if asset_df.empty:
-                continue
-
-            lines: list[str] = []
-            for ts, row in asset_df.iterrows():
-                dt = pd.Timestamp(ts)
-                dt = dt.tz_convert(None) if dt.tz is not None else dt
-                o = scaled_price(row["open"])
-                h = scaled_price(row["high"])
-                low_px = scaled_price(row["low"])
-                c = scaled_price(row["close"])
-                high_i = max(o, h, low_px, c)
-                low_i = min(o, h, low_px, c)
-                vol = max(1, int(round(float(row["volume"]))))
-                lines.append(f"{dt.strftime('%Y%m%d')} 00:00,{o},{high_i},{low_i},{c},{vol}")
-
-            zip_path = data_root / "daily" / f"{ticker_lower}.zip"
-            with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-                zf.writestr(f"{ticker_lower}.csv", "\n".join(lines))
-
-            first_dt = pd.Timestamp(asset_df.index[0])
-            first_dt = first_dt.tz_convert(None) if first_dt.tz is not None else first_dt
-            first_key = first_dt.strftime("%Y%m%d")
-            (data_root / "map_files" / f"{ticker_lower}.csv").write_text(
-                f"{first_key},{ticker_lower}\n20501231,{ticker_lower}\n",
-                encoding="utf-8",
-            )
-            (data_root / "factor_files" / f"{ticker_lower}.csv").write_text(
-                f"{first_key},1,1,1\n20501231,1,1,0\n",
-                encoding="utf-8",
-            )
-
-        manifest_path.write_text(
-            json.dumps(
-                {
-                    "signature": lean_data_sig,
-                    "num_assets": len(asset_names),
-                    "start": str(pd.Timestamp(dates[0]).date()),
-                    "end": str(pd.Timestamp(dates[-1]).date()),
-                }
-            ),
-            encoding="utf-8",
-        )
-
+    cache_hit = export_lean_daily_data(
+        data_root=data_root,
+        prices_by_asset=price_data,
+        asset_to_ticker=asset_to_ticker,
+        manifest_path=manifest_path,
+        signature_payload={
+            "signature": lean_data_sig,
+            "num_assets": len(asset_names),
+            "start": str(pd.Timestamp(dates[0]).date()),
+            "end": str(pd.Timestamp(dates[-1]).date()),
+        },
+    )
     prep_elapsed = time.perf_counter() - prep_start
     if cache_hit:
         _log(f"  LEAN data export: cache hit ({len(asset_names)} assets)")
@@ -2424,32 +2049,17 @@ class Ml4tBenchmark(QCAlgorithm):
         _log(f"  LEAN data export: {prep_elapsed:.2f}s ({len(asset_names)} assets)")
 
     output_dir = project_dir / "backtests" / f"{config.n_assets}_{config.n_bars}_{int(time.time())}"
-    if output_dir.exists():
-        shutil.rmtree(output_dir)
-
-    run_cmd = lean_cmd + [
-        "backtest",
-        str(project_dir),
-        "--lean-config",
-        str(lean_config),
-        "--no-update",
-        "--output",
-        str(output_dir),
-    ]
-
-    start_time = time.perf_counter()
-    run_result = subprocess.run(
-        run_cmd,
-        cwd=str(PROJECT_ROOT),
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=1800,
-    )
-    runtime_sec = time.perf_counter() - start_time
-
-    if run_result.returncode != 0:
-        error_text = (run_result.stderr or run_result.stdout).strip()
+    try:
+        runtime_sec = run_lean_backtest(
+            lean_cmd=lean_cmd,
+            cwd=PROJECT_ROOT,
+            project_dir=project_dir,
+            lean_config=lean_config,
+            output_dir=output_dir,
+            timeout=1800,
+            env=env,
+        )
+    except RuntimeError as exc:
         return BenchmarkResult(
             framework="LEAN CLI",
             scenario=config.name,
@@ -2457,12 +2067,21 @@ class Ml4tBenchmark(QCAlgorithm):
             num_trades=0,
             final_value=0,
             memory_mb=0,
-            error=f"LEAN backtest failed: {error_text}",
+            error=str(exc),
             target_trace_df=target_trace,
         )
 
-    summary_files = sorted(output_dir.glob("*-summary.json"))
-    if not summary_files:
+    copy_lean_artifacts(
+        project_dir,
+        output_dir,
+        ["ml4t_daily_equity.csv", "ml4t_order_events.csv", "ml4t_symbol_map.json"],
+    )
+
+    try:
+        num_trades, final_value, trades_df, equity_df, order_events_df = _load_lean_artifacts(
+            output_dir
+        )
+    except FileNotFoundError as exc:
         return BenchmarkResult(
             framework="LEAN CLI",
             scenario=config.name,
@@ -2470,25 +2089,9 @@ class Ml4tBenchmark(QCAlgorithm):
             num_trades=0,
             final_value=0,
             memory_mb=0,
-            error=f"LEAN summary file not found in {output_dir}",
+            error=str(exc),
             target_trace_df=target_trace,
         )
-
-    summary = json.loads(summary_files[-1].read_text(encoding="utf-8"))
-    trade_stats = summary.get("totalPerformance", {}).get("tradeStatistics", {})
-    stats = summary.get("statistics", {})
-    portfolio_stats = summary.get("totalPerformance", {}).get("portfolioStatistics", {})
-    state = summary.get("state", {})
-
-    num_trades = parse_int(trade_stats.get("totalNumberOfTrades"))
-    if num_trades == 0:
-        num_trades = parse_int(state.get("OrderCount"))
-    if num_trades == 0:
-        num_trades = parse_int(stats.get("Total Orders"))
-
-    final_value = parse_float(portfolio_stats.get("endEquity"))
-    if final_value == 0.0:
-        final_value = parse_float(stats.get("End Equity"))
 
     return BenchmarkResult(
         framework="LEAN CLI",
@@ -2497,6 +2100,9 @@ class Ml4tBenchmark(QCAlgorithm):
         num_trades=num_trades,
         final_value=final_value,
         memory_mb=0.0,
+        trades_df=trades_df,
+        equity_df=equity_df,
+        order_events_df=order_events_df,
         target_trace_df=target_trace,
     )
 
@@ -2579,14 +2185,14 @@ def run_scenario(
                     execution_mode="next_bar",
                     profile_override="zipline_strict",
                 )
-            elif framework == "ml4t-lean-strict":
+            elif framework == "ml4t-lean":
                 result = benchmark_ml4t(
                     config,
                     price_data,
                     signals,
                     dates,
-                    execution_mode="same_bar",
-                    profile_override="lean_strict",
+                    execution_mode="next_bar",
+                    profile_override="lean",
                 )
             elif framework == "vbt-pro":
                 result = benchmark_vectorbt_pro(config, price_data, signals, dates)
@@ -2691,7 +2297,7 @@ def main():
             "ml4t-vbt-strict",
             "ml4t-backtrader-strict",
             "ml4t-zipline-strict",
-            "ml4t-lean-strict",
+            "ml4t-lean",
             "vbt-pro",
             "vbt-oss",
             "backtrader",
@@ -2752,10 +2358,7 @@ def main():
     args = parser.parse_args()
 
     # Determine frameworks
-    if args.framework == "all":
-        frameworks = ["ml4t", "vbt-pro", "backtrader"]
-    else:
-        frameworks = [args.framework]
+    frameworks = ["ml4t", "vbt-pro", "backtrader"] if args.framework == "all" else [args.framework]
 
     # Determine scenarios
     if args.all or args.scenario == "all":


### PR DESCRIPTION
## Summary
- ship shared internal validation runners for LEAN, VectorBT, Backtrader, and Zipline under 
- refactor the benchmark suite to reuse those shared runners and update the LEAN parity profile/docs to the current verified semantics
- add focused runner/parity tests and refresh canonical validation docs/results for the Chapter 16 parity notebooks

## Verification
- uv run ty check
- uv run pytest tests/ -q
- uv build
