### PR TITLE
build: vendor docs theme as custom_dir overlay

### DIFF
--- a/docs/overrides/assets/javascripts/ml4t-docs-theme.js
+++ b/docs/overrides/assets/javascripts/ml4t-docs-theme.js
@@ -1,0 +1,1 @@
+document.documentElement.classList.add("ml4t-docs-theme");

--- a/docs/overrides/assets/stylesheets/ml4t-docs-theme.css
+++ b/docs/overrides/assets/stylesheets/ml4t-docs-theme.css
@@ -1,0 +1,413 @@
+:root {
+  --ml4t-navy: #0a1628;
+  --ml4t-navy-light: #152238;
+  --ml4t-navy-dark: #050b14;
+  --ml4t-slate: #1a2d4a;
+  --ml4t-amber: #d4a84b;
+  --ml4t-amber-light: #e4b85b;
+  --ml4t-off-white: #fafaf9;
+  --ml4t-warm-white: #f8f8f6;
+  --ml4t-silver: #c0c0c0;
+  --ml4t-silver-muted: #e8e8e6;
+  --ml4t-text: #334155;
+  --ml4t-text-light: #64748b;
+  --ml4t-text-dark: #1e293b;
+
+  --md-primary-fg-color: var(--ml4t-navy);
+  --md-primary-fg-color--light: var(--ml4t-navy-light);
+  --md-primary-fg-color--dark: var(--ml4t-navy-dark);
+  --md-accent-fg-color: var(--ml4t-amber);
+  --md-accent-fg-color--transparent: rgb(212 168 75 / 0.12);
+
+  /* FIX #2: Body background matches website off-white, not pure white */
+  --md-default-bg-color: var(--ml4t-off-white);
+  --md-default-bg-color--light: var(--ml4t-off-white);
+  --md-default-bg-color--lighter: var(--ml4t-off-white);
+  --md-default-bg-color--lightest: #ffffff;
+
+  --md-default-fg-color: var(--ml4t-text);
+  --md-default-fg-color--light: #475569;
+  --md-default-fg-color--lighter: var(--ml4t-text-light);
+  --md-default-fg-color--lightest: #94a3b8;
+  --md-code-bg-color: #f4f5f3;
+  --md-code-fg-color: var(--ml4t-navy);
+
+  /* Footer colors — match website footer */
+  --md-footer-bg-color: var(--ml4t-navy);
+  --md-footer-bg-color--dark: var(--ml4t-navy-dark);
+  --md-footer-fg-color: var(--ml4t-silver);
+  --md-footer-fg-color--light: var(--ml4t-text-light);
+  --md-footer-fg-color--lighter: var(--ml4t-silver-muted);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: var(--ml4t-navy);
+  --md-primary-fg-color--light: #203250;
+  --md-primary-fg-color--dark: #050b14;
+  --md-accent-fg-color: var(--ml4t-amber-light);
+  --md-default-bg-color: #09111d;
+  --md-default-bg-color--light: #0d1726;
+  --md-default-bg-color--lighter: #121d2e;
+  --md-default-bg-color--lightest: #162133;
+  --md-default-fg-color: var(--ml4t-warm-white);
+  --md-default-fg-color--light: #dbe2ea;
+  --md-default-fg-color--lighter: #a8b6c7;
+  --md-default-fg-color--lightest: #6f8094;
+  --md-code-bg-color: #101c2d;
+  --md-code-fg-color: var(--ml4t-warm-white);
+}
+
+/* ── Typography ────────────────────────────────────── */
+
+/* MkDocs Material sets html { font-size: 125% } (20px) which inflates
+   all rem values by 25%. Reset to 16px so docs text matches the website. */
+html {
+  font-size: 100% !important;
+}
+
+body {
+  font-family: "DM Sans", system-ui, sans-serif;
+  background-color: var(--ml4t-off-white) !important;
+}
+
+.md-typeset {
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4 {
+  font-family: "Source Serif 4", Georgia, serif;
+  letter-spacing: -0.015em;
+}
+
+.md-typeset h1 {
+  color: var(--ml4t-text-dark);
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 1.15;
+  margin-bottom: 1rem;
+}
+
+.md-typeset h2 {
+  color: var(--ml4t-text-dark);
+  font-size: 1.55rem;
+  font-weight: 600;
+  line-height: 1.25;
+  margin-top: 2.35rem;
+  padding-bottom: 0.45rem;
+  border-bottom: 1px solid var(--ml4t-silver-muted);
+}
+
+.md-typeset h3 {
+  color: var(--ml4t-text-dark);
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-top: 1.8rem;
+}
+
+/* ── Layout ────────────────────────────────────────── */
+
+.md-main__inner {
+  margin-top: 0;
+}
+
+.md-grid {
+  max-width: 80rem;
+}
+
+.md-content__inner {
+  margin: 0 auto;
+  padding: 2rem 1rem 0 2rem;
+}
+
+.md-content__inner > :first-child {
+  margin-top: 0;
+}
+
+.md-content {
+  max-width: 50rem;
+}
+
+.md-sidebar--primary,
+.md-sidebar--secondary {
+  padding-top: 1.5rem;
+}
+
+/* ── Header ────────────────────────────────────────── */
+
+/* The website navbar is injected by Django at serve time.
+   Hide the MkDocs header bar but keep the tabs as in-page
+   navigation that blends with the website's visual language. */
+.md-header {
+  background: white;
+  border-bottom: none;
+  box-shadow: none;
+}
+
+/* Collapse the MkDocs header bar to zero — only tabs remain visible */
+.md-header__inner {
+  display: none;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* Tabs styled as integrated sub-navigation — same visual
+   language as the chapter page tabs on the main website.
+   Uses px units because MkDocs sets html font-size: 125%. */
+.md-tabs {
+  background: white;
+  border-bottom: 2px solid var(--ml4t-silver-muted);
+  height: 49px;
+}
+
+.md-tabs__link {
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 14px !important;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ml4t-text-light) !important;
+  opacity: 1 !important;
+  padding: 12px 20px !important;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.md-tabs__link:hover {
+  color: var(--ml4t-text-dark) !important;
+  opacity: 1 !important;
+}
+
+.md-tabs__link--active,
+.md-tabs__link[data-md-state="active"],
+.md-tabs__item--active > .md-tabs__link {
+  color: var(--ml4t-navy) !important;
+  font-weight: 600;
+  border-bottom-color: var(--ml4t-amber);
+  opacity: 1 !important;
+}
+
+/* ── Navigation sidebar ───────────────────────────── */
+
+.md-nav__link--active {
+  color: var(--ml4t-amber);
+  font-weight: 600;
+}
+
+.md-nav__title,
+.md-nav__link {
+  font-size: 0.84rem;
+}
+
+.md-nav__title {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-weight: 600;
+  color: var(--ml4t-text-dark);
+  font-size: 0.9rem;
+}
+
+/* FIX #4: TOC sidebar — match website sidebar styling */
+.md-sidebar--secondary .md-nav__title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ml4t-text-light);
+  font-family: "DM Sans", system-ui, sans-serif;
+}
+
+.md-sidebar--secondary .md-nav__link {
+  font-size: 0.82rem;
+  color: var(--ml4t-text);
+  border-left: 2px solid transparent;
+  padding-left: 0.65rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.md-sidebar--secondary .md-nav__link:hover {
+  color: var(--ml4t-text-dark);
+  border-left-color: var(--ml4t-silver-muted);
+}
+
+.md-sidebar--secondary .md-nav__link--active {
+  color: var(--ml4t-navy);
+  border-left-color: var(--ml4t-amber);
+  font-weight: 600;
+}
+
+/* ── Content styling ───────────────────────────────── */
+
+.md-typeset a {
+  color: var(--ml4t-navy);
+  text-decoration-color: rgb(212 168 75 / 0.7);
+  text-underline-offset: 0.14em;
+}
+
+.md-typeset a:hover {
+  color: var(--ml4t-amber);
+}
+
+.md-typeset code,
+.md-typeset pre code {
+  font-family: "JetBrains Mono", monospace;
+}
+
+.md-typeset code {
+  border-radius: 0.35rem;
+}
+
+.md-typeset pre {
+  border: 1px solid var(--ml4t-silver-muted);
+  border-radius: 0.75rem;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.4);
+}
+
+/* Code copy button — visible on light background */
+.md-clipboard {
+  color: var(--ml4t-text-light);
+}
+
+.md-clipboard:hover {
+  color: var(--ml4t-amber);
+}
+
+.md-typeset table:not([class]) {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--ml4t-silver-muted);
+}
+
+.md-typeset table:not([class]) th {
+  background: var(--ml4t-navy);
+  color: var(--ml4t-warm-white);
+}
+
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: 0.75rem;
+  box-shadow: none;
+}
+
+/* ── Footer ───────────────────────────────────────── */
+
+/* FIX #3: Override MkDocs footer to match website footer styling.
+   The prev/next navigation uses website amber accents. */
+.md-footer {
+  background: var(--ml4t-navy);
+  color: var(--ml4t-silver);
+}
+
+.md-footer-nav__link {
+  opacity: 0.85;
+  transition: opacity 0.15s;
+}
+
+.md-footer-nav__link:hover {
+  opacity: 1;
+}
+
+.md-footer-nav__direction {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.6;
+}
+
+.md-footer-nav__title {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-weight: 600;
+}
+
+.md-footer-meta {
+  background: var(--ml4t-navy-dark);
+}
+
+/* ── Logo ──────────────────────────────────────────── */
+
+.ml4t-docs-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.12);
+  color: var(--ml4t-warm-white);
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+/* ── Custom footer meta ───────────────────────────── */
+
+.ml4t-footer-meta {
+  background: var(--ml4t-navy);
+  color: var(--ml4t-silver);
+}
+
+.ml4t-footer-meta__inner {
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.82rem;
+}
+
+.ml4t-footer-meta__inner strong {
+  color: var(--ml4t-warm-white);
+}
+
+.ml4t-footer-meta__links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.ml4t-footer-meta__links a {
+  color: inherit;
+  font-size: 0.82rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.ml4t-footer-meta__links a:hover {
+  color: var(--ml4t-amber);
+}
+
+/* ── Responsive ────────────────────────────────────── */
+
+@media screen and (max-width: 76.1875em) {
+  .md-content {
+    max-width: 100%;
+  }
+
+  .ml4t-footer-meta__inner {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    padding-top: 0.6rem;
+    padding-bottom: 0.6rem;
+  }
+}
+
+@media screen and (max-width: 44.9375em) {
+  .md-typeset h1 {
+    font-size: 1.7rem;
+  }
+
+  .md-typeset h2 {
+    font-size: 1.35rem;
+  }
+
+  .ml4t-footer-meta__links {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <link
+    rel="stylesheet"
+    href="{{ 'assets/stylesheets/ml4t-docs-theme.css' | url }}"
+  >
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=JetBrains+Mono:wght@400;600&family=Source+Serif+4:wght@500;600;700&display=swap"
+  >
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ 'assets/javascripts/ml4t-docs-theme.js' | url }}"></script>
+{% endblock %}

--- a/docs/overrides/partials/footer.html
+++ b/docs/overrides/partials/footer.html
@@ -1,0 +1,52 @@
+<footer class="md-footer">
+  <nav
+    class="md-footer__inner md-grid"
+    aria-label="{{ lang.t('footer') }}"
+  >
+    {% if page.previous_page %}
+      <a
+        href="{{ page.previous_page.url | url }}"
+        class="md-footer__link md-footer__link--prev"
+        aria-label="{{ lang.t('footer.previous') }}: {{ page.previous_page.title | e }}"
+      >
+        <div class="md-footer__button md-icon">
+          {% set icon = config.theme.icon.previous or "material/arrow-left" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </div>
+        <div class="md-footer__title">
+          <span class="md-footer__direction">{{ lang.t("footer.previous") }}</span>
+          <div class="md-ellipsis">{{ page.previous_page.title }}</div>
+        </div>
+      </a>
+    {% endif %}
+    {% if page.next_page %}
+      <a
+        href="{{ page.next_page.url | url }}"
+        class="md-footer__link md-footer__link--next"
+        aria-label="{{ lang.t('footer.next') }}: {{ page.next_page.title | e }}"
+      >
+        <div class="md-footer__title">
+          <span class="md-footer__direction">{{ lang.t("footer.next") }}</span>
+          <div class="md-ellipsis">{{ page.next_page.title }}</div>
+        </div>
+        <div class="md-footer__button md-icon">
+          {% set icon = config.theme.icon.next or "material/arrow-right" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </div>
+      </a>
+    {% endif %}
+  </nav>
+  <div class="ml4t-footer-meta">
+    <div class="ml4t-footer-meta__inner md-grid">
+      <div>
+        <strong>{{ config.site_name }}</strong>
+        <span> is part of the ML4T documentation suite.</span>
+      </div>
+      <div class="ml4t-footer-meta__links">
+        <a href="{{ config.extra.ml4t_docs_hub_url }}">Docs Hub</a>
+        <a href="{{ config.extra.ml4t_libraries_url }}">Libraries</a>
+        <a href="{{ config.extra.ml4t_chapters_url }}">Chapters</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/docs/overrides/partials/logo.html
+++ b/docs/overrides/partials/logo.html
@@ -1,0 +1,1 @@
+<span class="ml4t-docs-logo" aria-hidden="true">ML4T</span>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,9 @@ nav:
 
 # Extra configuration
 extra:
+  ml4t_docs_hub_url: /docs/
+  ml4t_libraries_url: /libraries/
+  ml4t_chapters_url: /chapters/
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/stefan-jansen


### PR DESCRIPTION
## Summary
- vendor the ML4T docs theme into `docs/overrides/` using MkDocs Material `custom_dir`
- update the footer partial to read ML4T hub URLs from `config.extra`
- keep the existing Material config and add the footer URL values to `mkdocs.yml`

## Validation
- `uv run mkdocs build --strict`

This removes the remaining dependency on an external docs-theme package at build time, so GitHub Actions can build docs from the repo contents alone.