### PR TITLE
fix: round next-bar rebalance exits for integer shares

### DIFF
--- a/src/ml4t/backtest/config.py
+++ b/src/ml4t/backtest/config.py
@@ -532,6 +532,10 @@ class BacktestConfig:
     next_bar_submission_precheck: bool = False
     next_bar_simple_cash_check: bool = False
     buying_power_reservation: bool = False  # Reserve cash at submission (LEAN-style)
+    # TODO(parity): consider an explicit profile/knob for "commit basket at close,
+    # fill reserved orders at next open" semantics. Keep it separate from the
+    # default next-bar/open path, which currently revalidates affordability at
+    # the actual open.
     next_bar_queue_shadow_validation: bool = False
     immediate_fill: bool = False  # Fill same-bar market orders at submit time (LEAN-style)
     rebalance_mode: RebalanceMode = RebalanceMode.INCREMENTAL

--- a/src/ml4t/backtest/core/execution_engine.py
+++ b/src/ml4t/backtest/core/execution_engine.py
@@ -64,6 +64,14 @@ class ExecutionEngine:
             if not self._is_exit_order(order):
                 deferred_entries.append(order)
                 continue
+            # Exit-first processing needs the same integer-share quantization as
+            # the generic per-order path; rebalance deltas often arrive as
+            # fractional target values even when the broker disallows them.
+            fill.apply_share_rounding(order)
+            if order.quantity <= 0:
+                order.status = OrderStatus.REJECTED
+                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
+                continue
             price = fill.get_fill_price_for_order(order, use_open)
             if price is None:
                 continue
@@ -382,6 +390,15 @@ class ExecutionEngine:
         is_exit = self._is_exit_order(order)
 
         if is_exit:
+            # Exit orders can originate from fractional target-value deltas during
+            # rebalances. Integer-share brokers must still quantize queued next-bar
+            # exits before fill, just like entry orders and immediate fills.
+            fill.apply_share_rounding(order)
+            if order.quantity <= 0:
+                order.status = OrderStatus.REJECTED
+                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
+                return
+
             fill_price = fill.check_fill(order, price)
             if fill_price is not None:
                 if use_simple_cash_check and not self._passes_simple_cash_check(order, fill_price):

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -6,6 +6,7 @@ import pytest
 from ml4t.specs.market_data import FeedSpec
 
 from ml4t.backtest.broker import Broker
+from ml4t.backtest.config import ShareType
 from ml4t.backtest.models import NoCommission, NoSlippage, PercentageCommission
 from ml4t.backtest.types import (
     ExecutionMode,
@@ -2028,6 +2029,58 @@ class TestNextBarExecutionMode:
         # Find exit fill (second fill)
         exit_fill = [f for f in broker.fills if f.order_id == exit_order.order_id][0]
         assert exit_fill.price == 107.0
+
+    def test_next_bar_rebalance_exit_rounds_integer_quantity(self):
+        """Rebalance exits in NEXT_BAR mode should honor integer share rounding."""
+        from ml4t.backtest.types import ExecutionMode
+
+        broker = Broker(1000.0, NoCommission(), NoSlippage(), share_type=ShareType.INTEGER)
+        broker.execution_mode = ExecutionMode.NEXT_BAR
+
+        broker._update_time(
+            timestamp=datetime(2024, 1, 1, 9, 30),
+            prices={"AAPL": 100.0, "MSFT": 100.0},
+            opens={"AAPL": 100.0, "MSFT": 100.0},
+            volumes={"AAPL": 1_000_000, "MSFT": 1_000_000},
+            highs={"AAPL": 100.0, "MSFT": 100.0},
+            lows={"AAPL": 100.0, "MSFT": 100.0},
+            signals={},
+        )
+        broker.rebalance_to_weights({"AAPL": 0.6, "MSFT": 0.4})
+
+        broker._update_time(
+            timestamp=datetime(2024, 1, 2, 9, 30),
+            prices={"AAPL": 110.0, "MSFT": 90.0},
+            opens={"AAPL": 100.0, "MSFT": 100.0},
+            volumes={"AAPL": 1_000_000, "MSFT": 1_000_000},
+            highs={"AAPL": 110.0, "MSFT": 90.0},
+            lows={"AAPL": 110.0, "MSFT": 90.0},
+            signals={},
+        )
+        broker._orders_this_bar.clear()
+        broker._process_orders(use_open=True)
+
+        broker.rebalance_to_weights({"AAPL": 0.2, "MSFT": 0.8})
+
+        broker._update_time(
+            timestamp=datetime(2024, 1, 3, 9, 30),
+            prices={"AAPL": 120.0, "MSFT": 80.0},
+            opens={"AAPL": 120.0, "MSFT": 80.0},
+            volumes={"AAPL": 1_000_000, "MSFT": 1_000_000},
+            highs={"AAPL": 120.0, "MSFT": 80.0},
+            lows={"AAPL": 120.0, "MSFT": 80.0},
+            signals={},
+        )
+        broker._orders_this_bar.clear()
+        broker._process_orders(use_open=True)
+
+        exit_fill = next(
+            fill
+            for fill in broker.fills
+            if fill.asset == "AAPL" and fill.side == OrderSide.SELL and fill.timestamp.date().isoformat() == "2024-01-03"
+        )
+
+        assert exit_fill.quantity == 4.0
 
 
 class TestBracketOrderParentCancellation:


### PR DESCRIPTION
## Summary
- round queued next-bar rebalance exits before fill under integer-share mode
- add a regression covering the fractional exit path
- document the future TODO for explicit close-commit/open-fill semantics

## Validation
- uv run ruff check src/ml4t/backtest/core/execution_engine.py tests/test_broker.py
- uv run pytest tests/test_broker.py -q -k 'next_bar_exit_uses_open_price or next_bar_rebalance_exit_rounds_integer_quantity'