### PR TITLE
fix: quantize integer participation fills

### DIFF
--- a/src/ml4t/backtest/execution/fill_executor.py
+++ b/src/ml4t/backtest/execution/fill_executor.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from ..config import InitialHwmSource
+from ..config import InitialHwmSource, ShareType
 from ..types import (
     ExitReason,
     Fill,
@@ -118,13 +118,20 @@ class FillExecutor:
             )
             fill_quantity = exec_result.fillable_quantity
 
+            if broker.share_type == ShareType.INTEGER:
+                fill_quantity = float(int(fill_quantity))
+
             if fill_quantity <= 0:
                 return False
 
             broker._filled_this_bar.add(order.order_id)
 
-            if exec_result.remaining_quantity > 0:
-                broker._partial_orders[order.order_id] = exec_result.remaining_quantity
+            remaining_quantity = max(0.0, effective_quantity - fill_quantity)
+            if broker.share_type == ShareType.INTEGER:
+                remaining_quantity = float(int(remaining_quantity))
+
+            if remaining_quantity > 0:
+                broker._partial_orders[order.order_id] = remaining_quantity
             else:
                 broker._partial_orders.pop(order.order_id, None)
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1795,6 +1795,65 @@ class TestExecutionLimitsIntegration:
         assert len(broker.fills) == 0
         assert order.status == OrderStatus.PENDING
 
+    def test_volume_participation_integer_share_rounding(self):
+        """Test capped fills stay integer-quantized for integer-share brokers."""
+        from ml4t.backtest.execution.limits import VolumeParticipationLimit
+
+        broker = Broker(
+            initial_cash=100000.0,
+            commission_model=NoCommission(),
+            slippage_model=NoSlippage(),
+            share_type=ShareType.INTEGER,
+            execution_limits=VolumeParticipationLimit(max_participation=0.10),
+        )
+
+        broker._update_time(
+            timestamp=datetime(2024, 1, 1, 9, 30),
+            prices={"AAPL": 100.0},
+            opens={"AAPL": 100.0},
+            volumes={"AAPL": 105.0},
+            highs={"AAPL": 101.0},
+            lows={"AAPL": 99.0},
+            signals={},
+        )
+
+        order = broker.submit_order("AAPL", 25.0, OrderSide.BUY)
+        broker._process_orders()
+
+        assert len(broker.fills) == 1
+        assert broker.fills[0].quantity == 10.0
+        assert broker._partial_orders[order.order_id] == 15.0
+
+    def test_volume_participation_integer_share_subunit_fill_stays_pending(self):
+        """Test sub-1-share participation caps do not create dust fills."""
+        from ml4t.backtest.execution.limits import VolumeParticipationLimit
+
+        broker = Broker(
+            initial_cash=100000.0,
+            commission_model=NoCommission(),
+            slippage_model=NoSlippage(),
+            share_type=ShareType.INTEGER,
+            execution_limits=VolumeParticipationLimit(max_participation=0.10),
+        )
+
+        broker._update_time(
+            timestamp=datetime(2024, 1, 1, 9, 30),
+            prices={"AAPL": 100.0},
+            opens={"AAPL": 100.0},
+            volumes={"AAPL": 5.0},
+            highs={"AAPL": 101.0},
+            lows={"AAPL": 99.0},
+            signals={},
+        )
+
+        order = broker.submit_order("AAPL", 1.0, OrderSide.BUY)
+        broker._process_orders()
+
+        assert len(broker.fills) == 0
+        assert order.status == OrderStatus.PENDING
+        assert order.order_id not in broker._partial_orders
+        assert broker.positions == {}
+
     def test_execution_limits_no_double_fill(self):
         """Test order not filled twice in same bar."""
         from ml4t.backtest.execution.limits import VolumeParticipationLimit


### PR DESCRIPTION
## Summary\n- re-quantize execution-limit fill quantities for integer-share brokers\n- recompute queued partial remainder after quantization\n- add regression coverage for capped integer fills and sub-1-share participation caps\n\n## Testing\n- uv run pytest tests/execution/test_limits.py tests/test_broker.py -q\n- uv run ruff check src/ml4t/backtest/execution/fill_executor.py tests/test_broker.py\n- uv run ty check