### PR TITLE
fix: restore main ci for integer rebalances

### DIFF
--- a/src/ml4t/backtest/core/execution_engine.py
+++ b/src/ml4t/backtest/core/execution_engine.py
@@ -496,7 +496,11 @@ class ExecutionEngine:
                     # Permissive mode: silently skip unaffordable orders for this cycle
                     # by cancelling them instead of keeping them pending forever.
                     order.status = OrderStatus.CANCELLED
-            elif broker.partial_fills_allowed and "insufficient" in rejection_reason.lower():
+            elif broker.partial_fills_allowed and "insufficient" in rejection_reason.lower() or (
+                order.rebalance_id is not None
+                and broker.share_type.value == "integer"
+                and "insufficient" in rejection_reason.lower()
+            ):
                 if fill.try_partial_fill(order, fill_price):
                     filled_orders.append(order)
                     broker._partial_orders.pop(order.order_id, None)

--- a/src/ml4t/backtest/core/order_book.py
+++ b/src/ml4t/backtest/core/order_book.py
@@ -162,7 +162,17 @@ class OrderBook:
             if not broker.skip_cash_validation:
                 valid, rejection_reason = broker.gatekeeper.validate_order(order, fill_price)
                 if not valid:
+                    allow_rebalance_partial = (
+                        order.rebalance_id is not None and broker.share_type.value == "integer"
+                    )
                     if broker.partial_fills_allowed and "insufficient" in rejection_reason.lower():
+                        if not fill.try_partial_fill(order, fill_price):
+                            order.status = OrderStatus.REJECTED
+                            order.rejection_reason = rejection_reason
+                            return order
+                        broker._partial_orders.pop(order.order_id, None)
+                        return order
+                    if allow_rebalance_partial and "insufficient" in rejection_reason.lower():
                         if not fill.try_partial_fill(order, fill_price):
                             order.status = OrderStatus.REJECTED
                             order.rejection_reason = rejection_reason

--- a/src/ml4t/backtest/datafeed.py
+++ b/src/ml4t/backtest/datafeed.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from typing import Any
 
 import polars as pl
-
 from ml4t.specs.market_data import FeedSpec
 
 

--- a/tests/contracts/test_execution_contracts.py
+++ b/tests/contracts/test_execution_contracts.py
@@ -4,12 +4,12 @@ from datetime import datetime, timedelta
 
 import polars as pl
 import pytest
+from ml4t.specs.market_data import FeedSpec
 
 from ml4t.backtest.config import BacktestConfig, CommissionType, ExecutionPrice, SlippageType
 from ml4t.backtest.engine import run_backtest
 from ml4t.backtest.strategy import Strategy
 from ml4t.backtest.types import ExecutionMode
-from ml4t.specs.market_data import FeedSpec
 
 
 def _prices() -> pl.DataFrame:

--- a/tests/execution/test_rebalancer.py
+++ b/tests/execution/test_rebalancer.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 import pytest
+from ml4t.specs.market_data import FeedSpec
 
 from ml4t.backtest import (
     Broker,
@@ -12,7 +13,6 @@ from ml4t.backtest.config import RebalanceMode
 from ml4t.backtest.execution.rebalancer import RebalanceConfig, TargetWeightExecutor
 from ml4t.backtest.execution.schedule import RebalanceSchedule
 from ml4t.backtest.models import NoCommission, NoSlippage
-from ml4t.specs.market_data import FeedSpec
 
 
 class TestRebalanceConfig:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -2136,7 +2136,9 @@ class TestNextBarExecutionMode:
         exit_fill = next(
             fill
             for fill in broker.fills
-            if fill.asset == "AAPL" and fill.side == OrderSide.SELL and fill.timestamp.date().isoformat() == "2024-01-03"
+            if fill.asset == "AAPL"
+            and fill.side == OrderSide.SELL
+            and fill.timestamp.date().isoformat() == "2024-01-03"
         )
 
         assert exit_fill.quantity == 4.0

--- a/tests/test_datafeed_memory.py
+++ b/tests/test_datafeed_memory.py
@@ -8,10 +8,10 @@ from datetime import datetime, timedelta
 
 import polars as pl
 import pytest
+from ml4t.specs.market_data import FeedSpec
 
 from ml4t.backtest import BacktestConfig, DataFeed
 from ml4t.backtest.config import DataFrequency
-from ml4t.specs.market_data import FeedSpec
 
 
 class TestDataFeedMemoryEfficiency:

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -3,11 +3,11 @@
 from datetime import datetime, timedelta
 
 import polars as pl
+from ml4t.specs.market_data import FeedSpec
 
 from ml4t.backtest import BacktestConfig, DataFeed, Engine, Strategy
 from ml4t.backtest.analytics.equity import EquityCurve
 from ml4t.backtest.config import DataFrequency
-from ml4t.specs.market_data import FeedSpec
 
 
 class TestEquityCurveAnnualization:

--- a/tests/test_strategy_templates.py
+++ b/tests/test_strategy_templates.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import polars as pl
+from ml4t.specs.market_data import FeedSpec
 
 from ml4t.backtest import BacktestConfig, DataFeed, Engine
 from ml4t.backtest.execution.schedule import RebalanceSchedule
@@ -13,7 +14,6 @@ from ml4t.backtest.strategies import (
     MomentumStrategy,
     SignalFollowingStrategy,
 )
-from ml4t.specs.market_data import FeedSpec
 
 
 def make_price_data(


### PR DESCRIPTION
## Summary
- allow integer-share rebalance entries to downsize to an affordable whole-share fill instead of full rejection
- restore the late-start asset contract case on current main
- clean up the format/import drift that was failing lint on main

## Validation
- uv run ruff format --check src tests
- uv run ruff check src tests
- uv run ty check
- uv run pytest tests/ -x --tb=short --no-cov
