### PR TITLE
feat: add broker equity accessor

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -58,6 +58,7 @@ Auto-generated from source docstrings.
         - get_position
         - get_positions
         - get_cash
+        - equity
         - get_account_value
         - get_rejected_orders
         - set_position_rules

--- a/docs/user-guide/stateful-strategies.md
+++ b/docs/user-guide/stateful-strategies.md
@@ -366,7 +366,8 @@ Stateful strategies depend on querying execution state. Key broker methods:
 |--------|---------|---------|
 | `get_position(asset)` | Position or None | All patterns |
 | `get_positions()` | Dict of all positions | Multi-asset |
-| `get_account_value()` | Total portfolio value | Sizing |
+| `equity()` | Current marked account equity | Sizing |
+| `get_account_value()` | Same value as `equity()` | Existing code |
 | `get_cash()` | Available cash | Capital allocation |
 | `get_asset_stats(asset)` | Trade statistics | Kelly sizing |
 | `get_order(order_id)` | Order status | Grid trading |

--- a/src/ml4t/backtest/broker.py
+++ b/src/ml4t/backtest/broker.py
@@ -736,9 +736,13 @@ class Broker:
         """
         return self.cash
 
+    def equity(self) -> float:
+        """Calculate current marked account equity."""
+        return self._portfolio_ledger.get_account_value()
+
     def get_account_value(self) -> float:
         """Calculate total account value (cash + position values)."""
-        return self._portfolio_ledger.get_account_value()
+        return self.equity()
 
     def get_rejected_orders(self, asset: str | None = None) -> list[Order]:
         """Get all rejected orders, optionally filtered by asset.

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -55,6 +55,21 @@ class TestBrokerBasics:
         value = broker.get_account_value()
         assert value == 100000.0
 
+    def test_equity_uses_current_mark_prices(self, broker_with_position):
+        """Test equity returns cash plus current marked position value."""
+        broker_with_position._update_time(
+            datetime(2024, 1, 2, 9, 30),
+            {"AAPL": 155.0},
+            {"AAPL": 154.0},
+            {"AAPL": 156.0},
+            {"AAPL": 153.0},
+            {"AAPL": 1000.0},
+            {},
+        )
+
+        assert broker_with_position.equity() == 115500.0
+        assert broker_with_position.get_account_value() == broker_with_position.equity()
+
     def test_get_position_none(self, broker):
         """Test get_position returns None for no position."""
         assert broker.get_position("AAPL") is None


### PR DESCRIPTION
## Summary
- add Broker.equity() as the preferred public account-equity accessor
- keep get_account_value() as an existing compatibility spelling that delegates to equity()
- document the accessor and add broker coverage

## Validation
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- pre-commit run --all-files
- uv run pytest tests/ -q
- uv build