### PR TITLE
fix: use single light docs palette

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,22 +13,11 @@ theme:
   custom_dir: docs/overrides
 
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: ml4t
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: custom
-      accent: amber
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+    scheme: default
+    primary: custom
+    accent: custom
 
-  font:
-    text: DM Sans
-    code: JetBrains Mono
+  font: false
 
   features:
     - navigation.tabs


### PR DESCRIPTION
## Summary
- switch the docs theme to a single explicit light palette
- disable MkDocs Material font injection so the shared docs theme CSS controls text rendering

Closes #19

## Validation
- uv run mkdocs build --strict
- pre-commit run --all-files