### PR TITLE
fix: resolve backtest review cleanup items

### DIFF
--- a/src/ml4t/backtest/accounting/gatekeeper.py
+++ b/src/ml4t/backtest/accounting/gatekeeper.py
@@ -4,6 +4,8 @@ This module provides the Gatekeeper class that validates orders before execution
 ensuring they meet account policy constraints and preventing invalid trades.
 """
 
+from collections.abc import Callable
+
 from ..models import CommissionModel
 from ..types import Order, OrderSide
 from .account import AccountState
@@ -42,6 +44,7 @@ class Gatekeeper:
         commission_model: CommissionModel,
         cash_buffer_pct: float = 0.0,
         settlement_reduces_buying_power: bool = True,
+        multiplier_resolver: Callable[[str], float] | None = None,
     ):
         """Initialize gatekeeper with account and commission model.
 
@@ -57,6 +60,7 @@ class Gatekeeper:
         self.commission_model = commission_model
         self.cash_buffer_pct = cash_buffer_pct
         self.settlement_reduces_buying_power = settlement_reduces_buying_power
+        self.multiplier_resolver = multiplier_resolver or (lambda _asset: 1.0)
 
     def _available_cash(self) -> float:
         """Cash available for new orders after applying buffer reserve and settlement holds."""
@@ -128,6 +132,7 @@ class Gatekeeper:
 
         # Determine order direction (positive=buy, negative=sell)
         order_qty_delta = self._calculate_quantity_delta(order.side, order.quantity)
+        multiplier = self.multiplier_resolver(order.asset)
 
         # Check for position reversal (long→short or short→long)
         # Delegate to policy's handle_reversal() method
@@ -141,6 +146,7 @@ class Gatekeeper:
                 current_positions=self.account.positions,
                 cash=self.account.cash,
                 commission=commission,
+                multiplier=multiplier,
             )
 
         # Check if this is a reducing order (closing/reducing existing position)
@@ -165,6 +171,7 @@ class Gatekeeper:
                 price=price,
                 current_positions=self.account.positions,
                 cash=available - commission,
+                multiplier=multiplier,
             )
         else:
             # Adding to existing position - use validate_position_change
@@ -175,6 +182,7 @@ class Gatekeeper:
                 price=price,
                 current_positions=self.account.positions,
                 cash=available - commission,
+                multiplier=multiplier,
             )
 
     def _is_reversal(self, current_qty: float, order_qty_delta: float) -> bool:

--- a/src/ml4t/backtest/accounting/policy.py
+++ b/src/ml4t/backtest/accounting/policy.py
@@ -26,6 +26,39 @@ if TYPE_CHECKING:
     from ..types import Position
 
 
+def _coerce_margin_pct_schedule(
+    schedule: dict[str, tuple[float, float]] | None,
+) -> dict[str, tuple[float, float]]:
+    if schedule is None:
+        return {}
+
+    coerced: dict[str, tuple[float, float]] = {}
+    for asset, value in schedule.items():
+        try:
+            initial, maintenance = value
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"margin_pct_schedule[{asset!r}] must be a two-item (initial, maintenance) sequence"
+            ) from exc
+        if not 0.0 < initial <= 1.0:
+            raise ValueError(
+                f"margin_pct_schedule[{asset!r}] initial margin must be in (0.0, 1.0], "
+                f"got {initial}"
+            )
+        if not 0.0 < maintenance <= 1.0:
+            raise ValueError(
+                f"margin_pct_schedule[{asset!r}] maintenance margin must be in (0.0, 1.0], "
+                f"got {maintenance}"
+            )
+        if maintenance >= initial:
+            raise ValueError(
+                f"margin_pct_schedule[{asset!r}] maintenance margin ({maintenance}) "
+                f"must be < initial margin ({initial})"
+            )
+        coerced[asset] = (float(initial), float(maintenance))
+    return coerced
+
+
 class AccountPolicy(ABC):
     """Abstract base class for account-specific trading constraints.
 
@@ -85,6 +118,8 @@ class AccountPolicy(ABC):
         price: float,
         current_positions: dict[str, Position],
         cash: float,
+        *,
+        multiplier: float = 1.0,
     ) -> tuple[bool, str]:
         """Validate whether a new position can be opened.
 
@@ -129,6 +164,8 @@ class AccountPolicy(ABC):
         current_positions: dict[str, Position],
         cash: float,
         commission: float,
+        *,
+        multiplier: float = 1.0,
     ) -> tuple[bool, str]:
         """Handle position reversal validation (long→short or short→long).
 
@@ -160,6 +197,8 @@ class AccountPolicy(ABC):
         price: float,
         current_positions: dict[str, Position],
         cash: float,
+        *,
+        multiplier: float = 1.0,
     ) -> tuple[bool, str]:
         """Validate a change to an existing position.
 
@@ -263,7 +302,7 @@ class UnifiedAccountPolicy(AccountPolicy):
         self.long_maintenance_margin = long_maintenance_margin
         self.short_maintenance_margin = short_maintenance_margin
         self.fixed_margin_schedule = fixed_margin_schedule or {}
-        self.margin_pct_schedule = margin_pct_schedule or {}
+        self.margin_pct_schedule = _coerce_margin_pct_schedule(margin_pct_schedule)
         if short_cash_policy not in {"credit", "credit_proceeds", "lock_notional"}:
             raise ValueError(
                 "short_cash_policy must be 'credit', 'credit_proceeds', or "
@@ -384,7 +423,11 @@ class UnifiedAccountPolicy(AccountPolicy):
         for pos in positions.values():
             price = pos.current_price if pos.current_price is not None else pos.entry_price
             required_initial_margin += self.get_margin_requirement(
-                pos.asset, pos.quantity, price, for_initial=True
+                pos.asset,
+                pos.quantity,
+                price,
+                for_initial=True,
+                multiplier=pos.multiplier,
             )
 
         # Buying power = excess equity / initial margin rate
@@ -397,6 +440,8 @@ class UnifiedAccountPolicy(AccountPolicy):
         quantity: float,
         price: float,
         for_initial: bool = True,
+        *,
+        multiplier: float = 1.0,
     ) -> float:
         """Calculate margin requirement for a position.
 
@@ -423,7 +468,7 @@ class UnifiedAccountPolicy(AccountPolicy):
         if asset in self.margin_pct_schedule:
             initial, maintenance = self.margin_pct_schedule[asset]
             margin_rate = initial if for_initial else maintenance
-            return abs(quantity * price) * margin_rate
+            return abs(quantity * price * multiplier) * margin_rate
 
         # Check for fixed margin (futures)
         if asset in self.fixed_margin_schedule:
@@ -432,7 +477,7 @@ class UnifiedAccountPolicy(AccountPolicy):
             return abs(quantity) * margin_per_contract
 
         # Percentage-based margin (equities)
-        market_value = abs(quantity * price)
+        market_value = abs(quantity * price * multiplier)
         if for_initial:
             return market_value * self.initial_margin
         else:
@@ -457,7 +502,11 @@ class UnifiedAccountPolicy(AccountPolicy):
         for pos in positions.values():
             price = pos.current_price if pos.current_price is not None else pos.entry_price
             required_maintenance += self.get_margin_requirement(
-                pos.asset, pos.quantity, price, for_initial=False
+                pos.asset,
+                pos.quantity,
+                price,
+                for_initial=False,
+                multiplier=pos.multiplier,
             )
 
         return nlv < required_maintenance
@@ -471,6 +520,8 @@ class UnifiedAccountPolicy(AccountPolicy):
         current_positions: dict[str, Position],
         cash: float,
         commission: float,
+        *,
+        multiplier: float = 1.0,
     ) -> tuple[bool, str]:
         """Handle position reversal validation (long→short or short→long)."""
         if not self.allow_short_selling:
@@ -478,7 +529,7 @@ class UnifiedAccountPolicy(AccountPolicy):
             return False, "Position reversal not allowed in cash account"
 
         # Simulate close: proceeds from closing the position
-        close_proceeds = abs(current_quantity * price)
+        close_proceeds = abs(current_quantity * price * multiplier)
 
         # Calculate cash after close (depends on leverage)
         if self.allow_leverage:
@@ -498,7 +549,7 @@ class UnifiedAccountPolicy(AccountPolicy):
 
         # Calculate the new opposite position
         new_qty = current_quantity + order_quantity_delta
-        new_position_cost = abs(new_qty * price)
+        new_position_cost = abs(new_qty * price * multiplier)
 
         if self.allow_leverage:
             # Margin: check buying power for new position
@@ -509,6 +560,7 @@ class UnifiedAccountPolicy(AccountPolicy):
                 price=price,
                 current_positions=positions_after_close,
                 cash=cash_after_close,
+                multiplier=multiplier,
             )
         else:
             # Crypto: check cash covers new position
@@ -529,13 +581,15 @@ class UnifiedAccountPolicy(AccountPolicy):
         price: float,
         current_positions: dict[str, Position],
         cash: float,
+        *,
+        multiplier: float = 1.0,
     ) -> tuple[bool, str]:
         """Validate whether a new position can be opened."""
         # Check short selling permission
         if quantity < 0 and not self.allow_short_selling:
             return False, "Short selling not allowed in cash account"
 
-        order_cost = abs(quantity * price)
+        order_cost = abs(quantity * price * multiplier)
 
         if (
             not self.allow_leverage
@@ -579,6 +633,8 @@ class UnifiedAccountPolicy(AccountPolicy):
         price: float,
         current_positions: dict[str, Position],
         cash: float,
+        *,
+        multiplier: float = 1.0,
     ) -> tuple[bool, str]:
         """Validate a change to an existing position."""
         new_quantity = current_quantity + quantity_delta
@@ -626,13 +682,13 @@ class UnifiedAccountPolicy(AccountPolicy):
         # Calculate order cost for validation
         if current_quantity == 0:
             # Opening new position
-            order_cost = abs(quantity_delta * price)
+            order_cost = abs(quantity_delta * price * multiplier)
         elif is_reversal:
             # Reversing: need resources for the new opposite portion
-            order_cost = abs(new_quantity * price)
+            order_cost = abs(new_quantity * price * multiplier)
         else:
             # Adding to position
-            order_cost = abs(quantity_delta * price)
+            order_cost = abs(quantity_delta * price * multiplier)
 
         if self.allow_leverage:
             # Margin: check buying power

--- a/src/ml4t/backtest/broker.py
+++ b/src/ml4t/backtest/broker.py
@@ -142,7 +142,7 @@ class Broker:
         self.settlement_reduces_buying_power = settlement_reduces_buying_power
         self._bar_index: int = 0
 
-        # Auto-populate fixed_margin_schedule from ContractSpec.margin
+        # Auto-populate margin schedules from ContractSpec settings
         # This lets users specify margin once on ContractSpec rather than duplicating
         # it in both ContractSpec and BacktestConfig.fixed_margin_schedule.
         effective_margin_schedule = dict(fixed_margin_schedule or {})
@@ -190,6 +190,7 @@ class Broker:
             self.commission_model,
             cash_buffer_pct=self.cash_buffer_pct,
             settlement_reduces_buying_power=self.settlement_reduces_buying_power,
+            multiplier_resolver=self.get_multiplier,
         )
 
         self.positions: dict[str, Position] = {}
@@ -741,7 +742,7 @@ class Broker:
         return self._portfolio_ledger.get_account_value()
 
     def get_account_value(self) -> float:
-        """Calculate total account value (cash + position values)."""
+        """Alias for equity()."""
         return self.equity()
 
     def get_rejected_orders(self, asset: str | None = None) -> list[Order]:

--- a/src/ml4t/backtest/config.py
+++ b/src/ml4t/backtest/config.py
@@ -281,6 +281,61 @@ def _feed_spec_to_dict(feed_spec: FeedSpec) -> dict[str, Any]:
     return serialize_artifact_value(asdict(feed_spec))
 
 
+def _coerce_margin_schedule(
+    schedule: dict[str, tuple[float, float]] | None,
+) -> dict[str, tuple[float, float]] | None:
+    if schedule is None:
+        return None
+    coerced: dict[str, tuple[float, float]] = {}
+    for asset, value in schedule.items():
+        try:
+            initial, maintenance = value
+        except (TypeError, ValueError):
+            coerced[asset] = value
+            continue
+        coerced[asset] = (float(initial), float(maintenance))
+    return coerced
+
+
+def _margin_schedule_to_dict(
+    schedule: dict[str, tuple[float, float]] | None,
+) -> dict[str, list[float]] | None:
+    if schedule is None:
+        return None
+    return {asset: [initial, maintenance] for asset, (initial, maintenance) in schedule.items()}
+
+
+def _validate_margin_pct_schedule(
+    schedule: dict[str, tuple[float, float]] | None,
+) -> list[str]:
+    issues: list[str] = []
+    if schedule is None:
+        return issues
+    for asset, value in schedule.items():
+        try:
+            initial, maintenance = value
+        except (TypeError, ValueError):
+            issues.append(
+                f"margin_pct_schedule[{asset!r}] must be a two-item (initial, maintenance) sequence"
+            )
+            continue
+        if not 0.0 < initial <= 1.0:
+            issues.append(
+                f"margin_pct_schedule[{asset!r}] initial margin ({initial}) must be in (0.0, 1.0]"
+            )
+        if not 0.0 < maintenance <= 1.0:
+            issues.append(
+                f"margin_pct_schedule[{asset!r}] maintenance margin ({maintenance}) "
+                "must be in (0.0, 1.0]"
+            )
+        if 0.0 < maintenance <= 1.0 and 0.0 < initial <= 1.0 and maintenance >= initial:
+            issues.append(
+                f"margin_pct_schedule[{asset!r}] maintenance margin ({maintenance}) "
+                f"must be < initial margin ({initial})"
+            )
+    return issues
+
+
 def _to_backtest_frequency(value: DataFrequency | Any | None) -> DataFrequency | None:
     if value is None:
         return None
@@ -521,6 +576,7 @@ class BacktestConfig:
                 "fixed_margin_schedule and margin_pct_schedule cannot both define: "
                 f"{overlapping_margin_assets}"
             )
+        issues.extend(_validate_margin_pct_schedule(self.margin_pct_schedule))
 
         if self.settlement_delay < 0 or self.settlement_delay > 5:
             issues.append(
@@ -640,6 +696,8 @@ class BacktestConfig:
         self._explicit_data_frequency = "data_frequency" in provided
         if hasattr(self, "_provided_init_fields"):
             delattr(self, "_provided_init_fields")
+        self.fixed_margin_schedule = _coerce_margin_schedule(self.fixed_margin_schedule)
+        self.margin_pct_schedule = _coerce_margin_schedule(self.margin_pct_schedule)
         if self.feed_spec is None:
             return
 
@@ -727,8 +785,8 @@ class BacktestConfig:
                 "initial_margin": self.initial_margin,
                 "long_maintenance_margin": self.long_maintenance_margin,
                 "short_maintenance_margin": self.short_maintenance_margin,
-                "fixed_margin_schedule": self.fixed_margin_schedule,
-                "margin_pct_schedule": self.margin_pct_schedule,
+                "fixed_margin_schedule": _margin_schedule_to_dict(self.fixed_margin_schedule),
+                "margin_pct_schedule": _margin_schedule_to_dict(self.margin_pct_schedule),
                 "short_cash_policy": self.short_cash_policy.value,
             },
             "execution": {
@@ -1032,7 +1090,7 @@ class BacktestConfig:
         """Save config to YAML file."""
         path = Path(path)
         with open(path, "w") as f:
-            yaml.dump(self.to_dict(), f, default_flow_style=False, sort_keys=False)
+            yaml.safe_dump(self.to_dict(), f, default_flow_style=False, sort_keys=False)
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> BacktestConfig:

--- a/src/ml4t/backtest/core/execution_engine.py
+++ b/src/ml4t/backtest/core/execution_engine.py
@@ -71,6 +71,11 @@ class ExecutionEngine:
         )
 
         for order in eligible_orders:
+            fill.apply_share_rounding(order)
+            if order.quantity <= 0:
+                order.status = OrderStatus.REJECTED
+                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
+                continue
             if self._is_exit_order(order):
                 exit_orders.append(order)
             else:
@@ -88,14 +93,6 @@ class ExecutionEngine:
             # go through the normal entry validation path.
             if not self._is_exit_order(order):
                 deferred_entries.append(order)
-                continue
-            # Exit-first processing needs the same integer-share quantization as
-            # the generic per-order path; rebalance deltas often arrive as
-            # fractional target values even when the broker disallows them.
-            fill.apply_share_rounding(order)
-            if order.quantity <= 0:
-                order.status = OrderStatus.REJECTED
-                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
                 continue
             price = fill.get_fill_price_for_order(order, use_open)
             if price is None:
@@ -218,7 +215,7 @@ class ExecutionEngine:
                 broker._partial_orders.pop(order.order_id, None)
             else:
                 fill.update_partial_order(order)
-            broker.mark_account_positions(use_open=False)
+            broker.mark_account_positions(use_open=use_open)
 
         self._cleanup_filled_orders(filled_orders)
 
@@ -245,6 +242,7 @@ class ExecutionEngine:
         commission = broker.commission_model.calculate(
             order.asset, order.quantity, validation_price
         )
+        multiplier = broker.get_multiplier(order.asset)
 
         if abs(current_qty) <= 1e-12:
             return policy.validate_new_position(
@@ -253,6 +251,7 @@ class ExecutionEngine:
                 price=validation_price,
                 current_positions=shadow_positions,
                 cash=shadow_cash - commission,
+                multiplier=multiplier,
             )
         if is_reversal:
             return policy.handle_reversal(
@@ -263,6 +262,7 @@ class ExecutionEngine:
                 current_positions=shadow_positions,
                 cash=shadow_cash,
                 commission=commission,
+                multiplier=multiplier,
             )
         return policy.validate_position_change(
             asset=order.asset,
@@ -271,6 +271,7 @@ class ExecutionEngine:
             price=validation_price,
             current_positions=shadow_positions,
             cash=shadow_cash - commission,
+            multiplier=multiplier,
         )
 
     def _commit_shadow_queue_fill(
@@ -382,16 +383,17 @@ class ExecutionEngine:
             if price is None:
                 continue
 
+            fill.apply_share_rounding(order)
+            if order.quantity <= 0:
+                order.status = OrderStatus.REJECTED
+                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
+                continue
+
             is_exit = self._is_exit_order(order)
 
             if is_exit or shadow_validated:
                 # Exits always fill (they free capital).
                 # Entries fill directly when shadow-validated at submission.
-                fill.apply_share_rounding(order)
-                if order.quantity <= 0:
-                    order.status = OrderStatus.REJECTED
-                    order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
-                    continue
                 fill_price = fill.check_fill(order, price)
                 if fill_price is not None:
                     fully_filled = fill.execute_fill(order, fill_price)
@@ -424,18 +426,15 @@ class ExecutionEngine:
             order, use_open
         )
 
+        fill.apply_share_rounding(order)
+        if order.quantity <= 0:
+            order.status = OrderStatus.REJECTED
+            order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
+            return
+
         is_exit = self._is_exit_order(order)
 
         if is_exit:
-            # Exit orders can originate from fractional target-value deltas during
-            # rebalances. Integer-share brokers must still quantize queued next-bar
-            # exits before fill, just like entry orders and immediate fills.
-            fill.apply_share_rounding(order)
-            if order.quantity <= 0:
-                order.status = OrderStatus.REJECTED
-                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
-                return
-
             fill_price = fill.check_fill(order, price)
             if fill_price is not None:
                 if use_simple_cash_check and not self._passes_simple_cash_check(order, fill_price):
@@ -472,12 +471,6 @@ class ExecutionEngine:
                 else:
                     fill.update_partial_order(order)
         else:
-            fill.apply_share_rounding(order)
-            if order.quantity <= 0:
-                order.status = OrderStatus.REJECTED
-                order.rejection_reason = "Quantity rounds to zero (share_type=INTEGER)"
-                return
-
             fill_price = fill.check_fill(order, price)
             if fill_price is None:
                 return
@@ -533,14 +526,9 @@ class ExecutionEngine:
                     # Permissive mode: silently skip unaffordable orders for this cycle
                     # by cancelling them instead of keeping them pending forever.
                     order.status = OrderStatus.CANCELLED
-            elif (
+            elif "insufficient" in rejection_reason.lower() and (
                 broker.partial_fills_allowed
-                and "insufficient" in rejection_reason.lower()
-                or (
-                    order.rebalance_id is not None
-                    and broker.share_type.value == "integer"
-                    and "insufficient" in rejection_reason.lower()
-                )
+                or (order.rebalance_id is not None and broker.share_type.value == "integer")
             ):
                 if fill.try_partial_fill(order, fill_price):
                     filled_orders.append(order)

--- a/src/ml4t/backtest/core/order_book.py
+++ b/src/ml4t/backtest/core/order_book.py
@@ -477,6 +477,7 @@ class OrderBook:
                 price=signal_price,
                 current_positions=shadow_positions,
                 cash=available_cash - commission,
+                multiplier=broker.get_multiplier(order.asset),
             )
         elif is_reversal:
             valid, reason = broker.account.policy.handle_reversal(
@@ -487,6 +488,7 @@ class OrderBook:
                 current_positions=shadow_positions,
                 cash=available_cash,
                 commission=commission,
+                multiplier=broker.get_multiplier(order.asset),
             )
         else:
             valid, reason = broker.account.policy.validate_position_change(
@@ -496,6 +498,7 @@ class OrderBook:
                 price=signal_price,
                 current_positions=shadow_positions,
                 cash=available_cash - commission,
+                multiplier=broker.get_multiplier(order.asset),
             )
 
         trace_counts = getattr(broker, "_trace_submission_precheck_counts", None)

--- a/tests/accounting/test_margin_account_policy.py
+++ b/tests/accounting/test_margin_account_policy.py
@@ -745,6 +745,38 @@ class TestMarginAccountPolicyFuturesMarginPct:
         margin = policy.get_margin_requirement("ES", 1, 5000.0, for_initial=True)
         assert margin == 250.0
 
+    def test_margin_pct_schedule_applies_contract_multiplier(self):
+        """Percentage-based futures margin should use full contract notional."""
+        policy = UnifiedAccountPolicy(
+            allow_short_selling=True,
+            allow_leverage=True,
+            margin_pct_schedule={"ES": (0.05, 0.035)},
+        )
+        margin = policy.get_margin_requirement("ES", 2, 5000.0, for_initial=True, multiplier=50.0)
+        assert margin == 25_000.0
+
+    def test_margin_pct_schedule_buying_power_uses_position_multiplier(self):
+        """Buying power should reserve percentage margin on full futures notional."""
+        policy = UnifiedAccountPolicy(
+            allow_short_selling=True,
+            allow_leverage=True,
+            margin_pct_schedule={"ES": (0.05, 0.035)},
+        )
+        positions = {
+            "ES": Position(
+                asset="ES",
+                quantity=2,
+                entry_price=5000.0,
+                entry_time=datetime(2024, 1, 2),
+                current_price=5000.0,
+                multiplier=50.0,
+            )
+        }
+
+        bp = policy.calculate_buying_power(100_000.0, positions)
+
+        assert bp == 1_150_000.0
+
     def test_reject_overlapping_fixed_and_percentage_margin(self):
         """A symbol must not define both fixed and percentage margin models."""
         with pytest.raises(ValueError, match="cannot both define"):

--- a/tests/test_config_wiring.py
+++ b/tests/test_config_wiring.py
@@ -125,6 +125,42 @@ class TestShareType:
         broker = _make_broker()
         assert broker.share_type == ShareType.INTEGER
 
+    def test_exit_first_classifies_after_integer_rounding(self):
+        broker = _make_broker(
+            initial_cash=0.0,
+            allow_short_selling=False,
+            fill_ordering=FillOrdering.EXIT_FIRST,
+            share_type=ShareType.INTEGER,
+            reject_on_insufficient_cash=True,
+        )
+        ts = datetime(2024, 1, 2)
+        _set_prices(broker, {"AAPL": 100.0, "MSFT": 100.0}, ts=ts)
+        broker.positions["AAPL"] = Position(
+            asset="AAPL",
+            quantity=5.0,
+            entry_price=100.0,
+            entry_time=ts,
+            current_price=100.0,
+        )
+        broker.account.positions["AAPL"] = Position(
+            asset="AAPL",
+            quantity=5.0,
+            entry_price=100.0,
+            entry_time=ts,
+            current_price=100.0,
+        )
+
+        buy = broker.submit_order("MSFT", 5, OrderSide.BUY)
+        sell = broker.submit_order("AAPL", 5.4, OrderSide.SELL)
+
+        broker._process_orders()
+
+        assert buy is not None
+        assert sell is not None
+        assert broker.get_position("AAPL") is None
+        assert broker.get_position("MSFT") is not None
+        assert buy.status.value == "filled"
+
 
 # ---------------------------------------------------------------------------
 # reject_on_insufficient_cash
@@ -966,6 +1002,25 @@ class TestImmediateFill:
         )
         issues = config.validate(warn=False)
         assert any("cannot both define" in issue for issue in issues)
+
+    def test_validate_rejects_malformed_margin_pct_schedule(self):
+        config = BacktestConfig(margin_pct_schedule={"ES": (0.05,)})  # type: ignore[dict-item]
+        issues = config.validate(warn=False)
+        assert any("margin_pct_schedule" in issue for issue in issues)
+
+    def test_validate_rejects_invalid_margin_pct_rates(self):
+        config = BacktestConfig(margin_pct_schedule={"ES": (0.03, 0.05)})
+        issues = config.validate(warn=False)
+        assert any("maintenance" in issue and "initial" in issue for issue in issues)
+
+    def test_margin_pct_schedule_yaml_roundtrip_is_safe(self, tmp_path):
+        config = BacktestConfig(margin_pct_schedule={"ES": (0.05, 0.035)})
+        path = tmp_path / "config.yaml"
+
+        config.to_yaml(path)
+        restored = BacktestConfig.from_yaml(path)
+
+        assert restored.margin_pct_schedule == {"ES": (0.05, 0.035)}
 
 
 class TestFromDictDefaultParity:


### PR DESCRIPTION
## Summary
- apply contract multipliers to percentage margin validation and buying power checks
- classify integer-share orders after rounding across execution paths
- validate and safely serialize percentage margin schedules
- clarify the legacy account value alias

## Verification
- uv run ruff check src tests
- uv run ty check
- uv run pytest tests/ -q
- pre-commit run --all-files
