### PR TITLE
chore: close remaining copilot cleanup items

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Benchmark on 250 assets x 20 years daily data (1.26M bars):
 
 ```bash
 git clone https://github.com/ml4t/backtest.git
-cd ml4t-backtest
+cd backtest
 uv sync
 uv run pytest tests/ -q
 uv run ty check

--- a/src/ml4t/backtest/core/execution_engine.py
+++ b/src/ml4t/backtest/core/execution_engine.py
@@ -508,6 +508,7 @@ class ExecutionEngine:
             else:
                 valid, rejection_reason = broker.gatekeeper.validate_order(order, fill_price)
 
+            insufficient_cash = "insufficient" in rejection_reason.lower()
             if valid:
                 fully_filled = fill.execute_fill(order, fill_price)
                 if fully_filled:
@@ -515,10 +516,7 @@ class ExecutionEngine:
                     broker._partial_orders.pop(order.order_id, None)
                 else:
                     fill.update_partial_order(order)
-            elif (
-                not broker.reject_on_insufficient_cash
-                and "insufficient" in rejection_reason.lower()
-            ):
+            elif not broker.reject_on_insufficient_cash and insufficient_cash:
                 if broker.partial_fills_allowed and fill.try_partial_fill(order, fill_price):
                     filled_orders.append(order)
                     broker._partial_orders.pop(order.order_id, None)
@@ -526,7 +524,7 @@ class ExecutionEngine:
                     # Permissive mode: silently skip unaffordable orders for this cycle
                     # by cancelling them instead of keeping them pending forever.
                     order.status = OrderStatus.CANCELLED
-            elif "insufficient" in rejection_reason.lower() and (
+            elif insufficient_cash and (
                 broker.partial_fills_allowed
                 or (order.rebalance_id is not None and broker.share_type.value == "integer")
             ):

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -58,13 +58,13 @@ class TestBrokerBasics:
     def test_equity_uses_current_mark_prices(self, broker_with_position):
         """Test equity returns cash plus current marked position value."""
         broker_with_position._update_time(
-            datetime(2024, 1, 2, 9, 30),
-            {"AAPL": 155.0},
-            {"AAPL": 154.0},
-            {"AAPL": 156.0},
-            {"AAPL": 153.0},
-            {"AAPL": 1000.0},
-            {},
+            timestamp=datetime(2024, 1, 2, 9, 30),
+            prices={"AAPL": 155.0},
+            opens={"AAPL": 154.0},
+            highs={"AAPL": 156.0},
+            lows={"AAPL": 153.0},
+            volumes={"AAPL": 1000.0},
+            signals={},
         )
 
         assert broker_with_position.equity() == 115500.0


### PR DESCRIPTION
## Summary
- fix README clone directory command
- use keyword arguments for the legacy `_update_time` test call
- compute the insufficient-cash predicate once in execution handling

## Verification
- uv run pytest tests/test_broker.py::TestBrokerBasics::test_equity_uses_current_mark_prices tests/test_config_wiring.py::TestShareType::test_exit_first_classifies_after_integer_rounding -q
- pre-commit run --files README.md src/ml4t/backtest/core/execution_engine.py tests/test_broker.py
