### PR TITLE
fix: harden margin schedule validation

### DIFF
--- a/src/ml4t/backtest/config.py
+++ b/src/ml4t/backtest/config.py
@@ -283,26 +283,32 @@ def _feed_spec_to_dict(feed_spec: FeedSpec) -> dict[str, Any]:
 
 def _coerce_margin_schedule(
     schedule: dict[str, tuple[float, float]] | None,
-) -> dict[str, tuple[float, float]] | None:
+) -> dict[str, Any] | None:
     if schedule is None:
         return None
-    coerced: dict[str, tuple[float, float]] = {}
+    coerced: dict[str, Any] = {}
     for asset, value in schedule.items():
         try:
             initial, maintenance = value
+            coerced[asset] = (float(initial), float(maintenance))
         except (TypeError, ValueError):
             coerced[asset] = value
-            continue
-        coerced[asset] = (float(initial), float(maintenance))
     return coerced
 
 
 def _margin_schedule_to_dict(
     schedule: dict[str, tuple[float, float]] | None,
-) -> dict[str, list[float]] | None:
+) -> dict[str, Any] | None:
     if schedule is None:
         return None
-    return {asset: [initial, maintenance] for asset, (initial, maintenance) in schedule.items()}
+    serialized: dict[str, Any] = {}
+    for asset, value in schedule.items():
+        try:
+            initial, maintenance = value
+            serialized[asset] = [float(initial), float(maintenance)]
+        except (TypeError, ValueError):
+            serialized[asset] = serialize_artifact_value(value)
+    return serialized
 
 
 def _validate_margin_pct_schedule(
@@ -318,6 +324,12 @@ def _validate_margin_pct_schedule(
             issues.append(
                 f"margin_pct_schedule[{asset!r}] must be a two-item (initial, maintenance) sequence"
             )
+            continue
+        try:
+            initial = float(initial)
+            maintenance = float(maintenance)
+        except (TypeError, ValueError):
+            issues.append(f"margin_pct_schedule[{asset!r}] values must be numeric")
             continue
         if not 0.0 < initial <= 1.0:
             issues.append(

--- a/tests/test_config_wiring.py
+++ b/tests/test_config_wiring.py
@@ -1008,6 +1008,18 @@ class TestImmediateFill:
         issues = config.validate(warn=False)
         assert any("margin_pct_schedule" in issue for issue in issues)
 
+    def test_validate_rejects_non_numeric_margin_pct_schedule(self):
+        config = BacktestConfig(
+            margin_pct_schedule={"ES": ("initial", "maintenance")}  # type: ignore[dict-item]
+        )
+        issues = config.validate(warn=False)
+        assert any("values must be numeric" in issue for issue in issues)
+
+    def test_invalid_margin_pct_schedule_export_does_not_raise(self):
+        config = BacktestConfig(margin_pct_schedule={"ES": (0.05,)})  # type: ignore[dict-item]
+        data = config.to_dict()
+        assert data["account"]["margin_pct_schedule"] == {"ES": [0.05]}
+
     def test_validate_rejects_invalid_margin_pct_rates(self):
         config = BacktestConfig(margin_pct_schedule={"ES": (0.03, 0.05)})
         issues = config.validate(warn=False)


### PR DESCRIPTION
## Summary
- keep malformed margin schedules representable so `BacktestConfig.validate()` can report issues
- make config export/YAML serialization tolerant of malformed schedule values
- report non-numeric margin schedule values as validation issues

## Verification
- uv run pytest tests/test_config_wiring.py::TestImmediateFill::test_validate_rejects_malformed_margin_pct_schedule tests/test_config_wiring.py::TestImmediateFill::test_validate_rejects_non_numeric_margin_pct_schedule tests/test_config_wiring.py::TestImmediateFill::test_invalid_margin_pct_schedule_export_does_not_raise tests/test_config_wiring.py::TestImmediateFill::test_margin_pct_schedule_yaml_roundtrip_is_safe -q
- pre-commit run --files src/ml4t/backtest/config.py tests/test_config_wiring.py
