### PR TITLE
test: bound invalid margin schedule iterator guard

### DIFF
--- a/tests/test_config_wiring.py
+++ b/tests/test_config_wiring.py
@@ -1029,6 +1029,8 @@ class TestImmediateFill:
                 return self
 
             def __next__(self):
+                if self.read_count >= 5:
+                    raise StopIteration
                 self.read_count += 1
                 return f"value-{self.read_count}"
 


### PR DESCRIPTION
## Summary
- make the invalid margin schedule iterator regression fixture finite
- preserve the zero-read assertion so future eager materialization fails without hanging tests

## Verification
- `uv run pytest tests/test_config_wiring.py::TestImmediateFill::test_invalid_margin_pct_schedule_export_keeps_non_sequences_scalar -q`
- `pre-commit run --files tests/test_config_wiring.py`
