### PR TITLE
feat: support per-asset pre-open position rules

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -72,6 +72,7 @@ Auto-generated from source docstrings.
         - get_target_intents
         - get_child_order_intents
         - get_intent_reconciliations
+        - get_target_rule_reconciliations
         - export_target_intent_state
         - restore_target_intent_state
         - update_order

--- a/docs/user-guide/execution-semantics.md
+++ b/docs/user-guide/execution-semantics.md
@@ -95,7 +95,22 @@ registration remains valid. If any target declares a policy, each target's decla
 authoritative and the intent-level field must be absent. Pass a mapping containing exactly the
 policy IDs referenced by that intent. A target without an ID has no target-managed rule.
 
+<!-- ml4t-doc-test: preopen-mixed-rules -->
 ```python
+from datetime import UTC, date, datetime
+
+import polars as pl
+from ml4t.specs import (
+    AssetTarget,
+    CanonicalTargetIntent,
+    IntentReason,
+    LifecyclePhase,
+    ResidualPolicy,
+    RoundingPolicy,
+    TargetMeasure,
+)
+
+from ml4t.backtest import BacktestConfig, DataFeed, Engine, Strategy
 from ml4t.backtest.risk.position import StopLoss, TrailingStop
 
 decision = datetime(2026, 8, 2, 20, 0, tzinfo=UTC)
@@ -128,13 +143,41 @@ mixed_target = CanonicalTargetIntent(
     reason=IntentReason.REBALANCE,
 )
 
-broker.register_target_intent(
-    mixed_target,
-    position_rules={
-        "spy-stop-5": StopLoss(0.05),
-        "qqq-trail-8": TrailingStop(0.08),
-    },
+class MixedRuleStrategy(Strategy):
+    def on_prepare(self, broker, config=None):
+        broker.register_target_intent(
+            mixed_target,
+            position_rules={
+                "spy-stop-5": StopLoss(0.05),
+                "qqq-trail-8": TrailingStop(0.08),
+            },
+        )
+
+    def on_data(self, timestamp, data, context, broker):
+        pass
+
+
+assets = ("SPY", "QQQ", "IWM")
+prices = pl.DataFrame(
+    {
+        "timestamp": [datetime(2026, 8, 3)] * len(assets),
+        "asset": assets,
+        "open": [100.0] * len(assets),
+        "high": [101.0] * len(assets),
+        "low": [99.0] * len(assets),
+        "close": [100.0] * len(assets),
+        "volume": [1_000_000.0] * len(assets),
+    }
 )
+engine = Engine(
+    DataFeed(prices_df=prices),
+    MixedRuleStrategy(),
+    BacktestConfig(retain_intent_history=True),
+)
+result = engine.run()
+
+assert result.metrics["target_intent_count"] == 1
+assert result.metrics["target_rule_reconciliation_count"] == 3
 ```
 
 Registration validates the complete mapping before changing manager state. Missing

--- a/docs/user-guide/execution-semantics.md
+++ b/docs/user-guide/execution-semantics.md
@@ -82,12 +82,63 @@ def on_prepare(self, broker, config=None):
 ```
 
 The engine validates the cutoff, lowers the target at the opening auction, records canonical child
-intent and order lineage, reconciles fills and remaining quantity, then activates any associated
-position rules. Opening child orders use OPG time-in-force: any quantity not filled by the eligible
-opening auction is cancelled and is never carried into a later bar. A scheduled target uses the
-same method from an earlier event with a future
+intent and order lineage, reconciles fills and remaining quantity, then applies each target's
+position rule to the resulting position. Opening child orders use OPG time-in-force: any quantity
+not filled by the eligible opening auction is cancelled and is never carried into a later bar. A
+scheduled target uses the same method from an earlier event with a future
 `effective_session`. Same-session registration from `on_data()` is rejected because that callback
 has already observed information after the opening phase.
+
+Targets support two position-rule declaration modes. If no `AssetTarget` declares a policy, the
+intent-level `position_rule_policy_id` applies to every asset and the existing single-rule
+registration remains valid. If any target declares a policy, each target's declaration is
+authoritative and the intent-level field must be absent. Pass a mapping containing exactly the
+policy IDs referenced by that intent. A target without an ID has no target-managed rule.
+
+```python
+from ml4t.backtest.risk.position import StopLoss, TrailingStop
+
+decision = datetime(2026, 8, 2, 20, 0, tzinfo=UTC)
+mixed_target = CanonicalTargetIntent(
+    intent_id="mixed-risk-portfolio",
+    decision_time=decision,
+    information_cutoff=decision,
+    effective_session=date(2026, 8, 3),
+    effective_phase=LifecyclePhase.PRE_OPEN,
+    targets=(
+        AssetTarget(
+            "SPY",
+            TargetMeasure.WEIGHT,
+            0.40,
+            position_rule_policy_id="spy-stop-5",
+        ),
+        AssetTarget(
+            "QQQ",
+            TargetMeasure.WEIGHT,
+            0.40,
+            position_rule_policy_id="qqq-trail-8",
+        ),
+        AssetTarget("IWM", TargetMeasure.WEIGHT, 0.15),
+    ),
+    idempotency_key="mixed-risk-portfolio-2026-08-03",
+    measure=TargetMeasure.WEIGHT,
+    cash_buffer=0.05,
+    rounding=RoundingPolicy.TOWARD_ZERO,
+    residual=ResidualPolicy.KEEP_CASH,
+    reason=IntentReason.REBALANCE,
+)
+
+broker.register_target_intent(
+    mixed_target,
+    position_rules={
+        "spy-stop-5": StopLoss(0.05),
+        "qqq-trail-8": TrailingStop(0.08),
+    },
+)
+```
+
+Registration validates the complete mapping before changing manager state. Missing
+implementations, conflicting definitions, and unreferenced mapping keys reject the request.
 
 `ExecutionPolicy.liquidity_fraction` applies only to opening-auction child orders. A value of 1.0
 means no participation constraint, even when the requested quantity exceeds the bar volume. A
@@ -115,10 +166,15 @@ Use `KEEP_CASH`; unsupported combinations are rejected before opening orders are
 restored.
 
 A position rule associated with a target remains active until the position becomes flat or a later
-filled target for that asset replaces it. If the later target does not name a
-`position_rule_policy_id`, the earlier target-managed rule is removed. An explicit rule override
-installed through the broker remains in place because target cleanup removes only the rule object
-installed by the target manager.
+target changes it. Repeating the same policy ID preserves the installed rule object, its state, and
+its activation time. A different ID installs a fresh rule at that opening. A target with no
+resolved ID removes the earlier target-managed rule and its activation context. These transitions
+use the actual post-auction position, including a carried position after a partial fill, rejected
+order, or zero quantity change. A failed new entry does not activate a rule. An explicit rule
+override installed through the broker remains in place during target cleanup because cleanup
+removes only the exact rule object installed by the target manager. Use
+`get_target_rule_reconciliations()` to inspect the requested, prior, and resulting policy ID for
+every asset target.
 
 `export_target_intent_state()` does not contain account or order-book state. Restoring state that
 already contains child orders therefore requires those orders and the corresponding account state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires-python = ">=3.12"
 
 # Core dependencies
 dependencies = [
-    "ml4t-specs>=0.1.1,<0.2",
+    "ml4t-specs>=0.1.2,<0.2",
     "polars>=1.36.1",
     "pandas>=2.3.3; python_version < '3.15'",
     "pandas>=3.0.5; python_version >= '3.15'",

--- a/src/ml4t/backtest/__init__.py
+++ b/src/ml4t/backtest/__init__.py
@@ -35,6 +35,8 @@ from .preopen import (
     IntentReconciliation,
     LateAuctionIntentError,
     PreOpenIntentError,
+    TargetRuleOutcome,
+    TargetRuleReconciliation,
     UnsupportedPreOpenPolicyError,
     default_execution_policy,
 )
@@ -121,6 +123,8 @@ __all__ = [
     "IntentReconciliation",
     "LateAuctionIntentError",
     "PreOpenIntentError",
+    "TargetRuleOutcome",
+    "TargetRuleReconciliation",
     "UnsupportedPreOpenPolicyError",
     "default_execution_policy",
     # Risk rules

--- a/src/ml4t/backtest/broker.py
+++ b/src/ml4t/backtest/broker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypedDict, Unpack
 from zoneinfo import ZoneInfo
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from .accounting.policy import AccountPolicy
     from .config import BacktestConfig
     from .execution import ExecutionLimits, MarketImpactModel
-    from .preopen import IntentReconciliation, PreOpenTargetManager
+    from .preopen import IntentReconciliation, PreOpenTargetManager, TargetRuleReconciliation
     from .risk.position import PositionRule
     from .sessions import SessionConfig
 
@@ -1355,7 +1355,7 @@ class Broker:
         self,
         intent: CanonicalTargetIntent,
         *,
-        position_rules: PositionRule | None = None,
+        position_rules: PositionRule | Mapping[str, PositionRule] | None = None,
     ) -> CanonicalTargetIntent:
         """Register an idempotent target for a causal opening phase."""
         self._capture_lifecycle_mutation(target_intents=True)
@@ -1391,6 +1391,12 @@ class Broker:
         if self._preopen_target_manager is None:
             return ()
         return self._preopen_target_manager.reconciliations
+
+    def get_target_rule_reconciliations(self) -> tuple[TargetRuleReconciliation, ...]:
+        """Return retained per-target rule transition evidence."""
+        if self._preopen_target_manager is None:
+            return ()
+        return self._preopen_target_manager.target_rule_reconciliations
 
     def export_target_intent_state(self) -> dict[str, Any]:
         """Serialize accepted target, child, and reconciliation state."""

--- a/src/ml4t/backtest/engine.py
+++ b/src/ml4t/backtest/engine.py
@@ -615,9 +615,13 @@ class Engine:
             "target_intent_count": self.preopen_target_manager.target_count,
             "child_order_intent_count": self.preopen_target_manager.child_count,
             "intent_reconciliation_count": self.preopen_target_manager.reconciliation_count,
+            "target_rule_reconciliation_count": (
+                self.preopen_target_manager.target_rule_reconciliation_count
+            ),
             "target_intents": [],
             "child_order_intents": [],
             "intent_reconciliations": [],
+            "target_rule_reconciliations": [],
         }
         if retain_intent_history:
             contract_evidence.update(
@@ -630,6 +634,10 @@ class Engine:
                     ],
                     "intent_reconciliations": [
                         record.to_dict() for record in self.preopen_target_manager.reconciliations
+                    ],
+                    "target_rule_reconciliations": [
+                        record.to_dict()
+                        for record in self.preopen_target_manager.target_rule_reconciliations
                     ],
                 }
             )

--- a/src/ml4t/backtest/preopen.py
+++ b/src/ml4t/backtest/preopen.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import copy
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ml4t.specs import (
     BarPathPolicy,
@@ -74,6 +75,57 @@ class IntentOutcome(StrEnum):
     PENDING = "pending"
     REJECTED = "rejected"
     CANCELLED = "cancelled"
+
+
+class TargetRuleOutcome(StrEnum):
+    """Resulting rule state for one asset target after the opening auction."""
+
+    ACTIVATED = "activated"
+    PRESERVED = "preserved"
+    CLEARED = "cleared"
+    NO_POSITION = "no_position"
+
+
+@dataclass(frozen=True, slots=True)
+class TargetRuleReconciliation:
+    """Requested and realized target-managed rule state for one asset."""
+
+    target_intent_id: str
+    asset: str
+    event_time: datetime
+    requested_policy_id: str | None
+    prior_policy_id: str | None
+    resulting_policy_id: str | None
+    outcome: TargetRuleOutcome
+    activated_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible reconciliation record."""
+        return {
+            "target_intent_id": self.target_intent_id,
+            "asset": self.asset,
+            "event_time": self.event_time.isoformat(),
+            "requested_policy_id": self.requested_policy_id,
+            "prior_policy_id": self.prior_policy_id,
+            "resulting_policy_id": self.resulting_policy_id,
+            "outcome": self.outcome.value,
+            "activated_at": self.activated_at.isoformat() if self.activated_at else None,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any]) -> TargetRuleReconciliation:
+        """Restore one target-rule reconciliation record."""
+        activation = value.get("activated_at")
+        return cls(
+            target_intent_id=value["target_intent_id"],
+            asset=value["asset"],
+            event_time=datetime.fromisoformat(value["event_time"]),
+            requested_policy_id=value.get("requested_policy_id"),
+            prior_policy_id=value.get("prior_policy_id"),
+            resulting_policy_id=value.get("resulting_policy_id"),
+            outcome=TargetRuleOutcome(value["outcome"]),
+            activated_at=datetime.fromisoformat(activation) if activation else None,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -210,9 +262,10 @@ class PreOpenTargetManager:
         self._active_children: set[str] = set()
         self._processed_targets: set[str] = set()
         self._reconciliations: list[IntentReconciliation] = []
+        self._target_rule_reconciliations: list[TargetRuleReconciliation] = []
+        self._target_rule_by_intent_asset: dict[tuple[str, str], TargetRuleReconciliation] = {}
         self._latest_reconciliation: dict[str, IntentReconciliation] = {}
         self._terminal_children: set[str] = set()
-        self._rule_activations: dict[str, datetime] = {}
         self._position_rules: dict[str, PositionRule] = {}
         self._active_rule_policy_by_asset: dict[str, str] = {}
         self._installed_rule_by_asset: dict[str, PositionRule] = {}
@@ -233,6 +286,11 @@ class PreOpenTargetManager:
         return tuple(self._reconciliations)
 
     @property
+    def target_rule_reconciliations(self) -> tuple[TargetRuleReconciliation, ...]:
+        """Return retained per-target rule reconciliation history."""
+        return tuple(self._target_rule_reconciliations)
+
+    @property
     def target_count(self) -> int:
         """Return the number of accepted targets without copying them."""
         return len(self._targets)
@@ -247,11 +305,16 @@ class PreOpenTargetManager:
         """Return the number of retained reconciliation records without copying them."""
         return len(self._reconciliations)
 
+    @property
+    def target_rule_reconciliation_count(self) -> int:
+        """Return the number of retained target-rule reconciliation records."""
+        return len(self._target_rule_reconciliations)
+
     def register(
         self,
         intent: CanonicalTargetIntent,
         *,
-        position_rules: PositionRule | None = None,
+        position_rules: PositionRule | Mapping[str, PositionRule] | None = None,
         active_phase: LifecyclePhase | None = None,
     ) -> CanonicalTargetIntent:
         """Accept one idempotent target without reading feed prices."""
@@ -278,22 +341,56 @@ class PreOpenTargetManager:
                 f"{active_phase.value} after its pre-open decision phase"
             )
         self._validate_residual_policy(intent)
-        policy_id = intent.position_rule_policy_id
-        policy_registration: tuple[str, PositionRule] | None = None
-        if position_rules is not None and policy_id is None:
-            raise PreOpenIntentError(
-                "position_rules require CanonicalTargetIntent.position_rule_policy_id"
-            )
-        if position_rules is not None and policy_id is not None:
-            policy_registration = (policy_id, position_rules)
-            existing_rules = self._position_rules.get(policy_registration[0])
-            if existing_rules is not None and existing_rules != position_rules:
+        target_policy_ids = {
+            target.position_rule_policy_id
+            for target in intent.targets
+            if target.position_rule_policy_id is not None
+        }
+        target_level_mode = bool(target_policy_ids)
+        referenced_policy_ids = (
+            target_policy_ids
+            if target_level_mode
+            else ({intent.position_rule_policy_id} if intent.position_rule_policy_id else set())
+        )
+        policy_registrations: dict[str, PositionRule] = {}
+        if isinstance(position_rules, Mapping):
+            supplied_rules = cast("Mapping[str, PositionRule]", position_rules)
+            supplied_policy_ids = set(supplied_rules)
+            unreferenced = supplied_policy_ids.difference(referenced_policy_ids)
+            if unreferenced:
+                raise PreOpenIntentError(
+                    "position_rules contains unreferenced policy IDs: "
+                    + ", ".join(sorted(unreferenced))
+                )
+            for policy_id, rules in supplied_rules.items():
+                policy_registrations[policy_id] = rules
+        elif position_rules is not None:
+            if target_level_mode:
+                raise PreOpenIntentError(
+                    "target-level position rule policies require a policy-ID mapping"
+                )
+            if intent.position_rule_policy_id is None:
+                raise PreOpenIntentError(
+                    "position_rules require CanonicalTargetIntent.position_rule_policy_id"
+                )
+            policy_registrations[intent.position_rule_policy_id] = position_rules
+        for policy_id, rules in policy_registrations.items():
+            if not policy_id:
+                raise PreOpenIntentError("position rule policy IDs must be non-empty")
+            existing_rules = self._position_rules.get(policy_id)
+            if existing_rules is not None and existing_rules != rules:
                 raise PreOpenIntentError(
                     f"position rule policy {policy_id!r} is already registered"
                 )
-        elif policy_id is not None and policy_id not in self._position_rules:
+        missing_policy_ids = sorted(
+            policy_id
+            for policy_id in referenced_policy_ids
+            if policy_id not in self._position_rules and policy_id not in policy_registrations
+        )
+        if missing_policy_ids:
             raise UnsupportedPreOpenPolicyError(
-                f"position rule policy {policy_id!r} has no registered implementation"
+                "position rule policies have no registered implementation: "
+                + ", ".join(missing_policy_ids)
             )
         existing_id = self._idempotency.get(intent.idempotency_key)
         if existing_id is not None:
@@ -302,8 +399,8 @@ class PreOpenTargetManager:
                 raise PreOpenIntentError(
                     f"idempotency key {intent.idempotency_key!r} identifies a different target"
                 )
-            if policy_registration is not None:
-                self.register_position_rule_policy(*policy_registration)
+            for policy_id, rules in policy_registrations.items():
+                self.register_position_rule_policy(policy_id, rules)
             return existing
         if intent.intent_id in self._targets:
             raise PreOpenIntentError(f"duplicate target intent_id {intent.intent_id!r}")
@@ -330,8 +427,8 @@ class PreOpenTargetManager:
                 f"target {intent.intent_id!r} overlaps target {registered_id!r} for "
                 f"{', '.join(sorted(overlap))} in session {intent.effective_session}"
             )
-        if policy_registration is not None:
-            self.register_position_rule_policy(*policy_registration)
+        for policy_id, rules in policy_registrations.items():
+            self.register_position_rule_policy(policy_id, rules)
         self._targets[intent.intent_id] = intent
         self._target_by_session_asset.update(
             ((intent.effective_session, asset), intent.intent_id) for asset in assets
@@ -456,10 +553,11 @@ class PreOpenTargetManager:
                         + ", ".join(sorted(nonterminal))
                     )
             self._processed_targets.add(intent.intent_id)
+            self._reconcile_target_rules(intent, timestamp)
             self.reconcile(timestamp, target_intent_id=intent.intent_id)
 
     def reconcile(self, timestamp: datetime, *, target_intent_id: str | None = None) -> None:
-        """Record current child outcomes and activate rules after observed fills."""
+        """Record current child outcomes after observed opening fills."""
         for child_id in tuple(self._active_children):
             child = self._children[child_id]
             if target_intent_id is not None and child.target_intent_id != target_intent_id:
@@ -483,7 +581,9 @@ class PreOpenTargetManager:
             else:
                 outcome = IntentOutcome.PENDING
             intent = self._targets[child.target_intent_id]
-            activation = self._activate_rules(intent, child.asset, timestamp, filled)
+            target_rule = self._target_rule_by_intent_asset.get(
+                (child.target_intent_id, child.asset)
+            )
             record = IntentReconciliation(
                 target_intent_id=child.target_intent_id,
                 child_intent_id=child.child_intent_id,
@@ -494,8 +594,8 @@ class PreOpenTargetManager:
                 remaining_quantity=remaining,
                 outcome=outcome,
                 rejection_reason=order.rejection_reason,
-                rule_policy_id=intent.position_rule_policy_id,
-                rule_activated_at=activation,
+                rule_policy_id=self._policy_id_for_asset(intent, child.asset),
+                rule_activated_at=(target_rule.activated_at if target_rule is not None else None),
             )
             previous = self._latest_reconciliation.get(child.child_intent_id)
             if previous is None or not self._same_reconciliation_state(previous, record):
@@ -519,6 +619,9 @@ class PreOpenTargetManager:
             "order_by_child": dict(self._order_by_child),
             "processed_targets": sorted(self._processed_targets),
             "reconciliations": [record.to_dict() for record in self._reconciliations],
+            "target_rule_reconciliations": [
+                record.to_dict() for record in self._target_rule_reconciliations
+            ],
             "active_rule_policy_by_asset": dict(self._active_rule_policy_by_asset),
         }
 
@@ -533,9 +636,10 @@ class PreOpenTargetManager:
             or self._active_children
             or self._processed_targets
             or self._reconciliations
+            or self._target_rule_reconciliations
+            or self._target_rule_by_intent_asset
             or self._latest_reconciliation
             or self._terminal_children
-            or self._rule_activations
             or self._active_rule_policy_by_asset
             or self._installed_rule_by_asset
         ):
@@ -568,12 +672,13 @@ class PreOpenTargetManager:
         reconciliations = [
             IntentReconciliation.from_mapping(raw) for raw in state.get("reconciliations", ())
         ]
+        target_rule_reconciliations = [
+            TargetRuleReconciliation.from_mapping(raw)
+            for raw in state.get("target_rule_reconciliations", ())
+        ]
         latest_reconciliation: dict[str, IntentReconciliation] = {}
-        rule_activations: dict[str, datetime] = {}
         for record in reconciliations:
             latest_reconciliation[record.child_intent_id] = record
-            if record.rule_activated_at is not None:
-                rule_activations.setdefault(record.child_intent_id, record.rule_activated_at)
         nonterminal_children = {
             child_id
             for child_id, record in latest_reconciliation.items()
@@ -589,6 +694,19 @@ class PreOpenTargetManager:
         unknown_children = set(order_by_child).difference(children)
         if unknown_targets or unknown_children:
             raise PreOpenIntentError("target intent state contains unknown target or child ids")
+        target_rule_by_intent_asset: dict[tuple[str, str], TargetRuleReconciliation] = {}
+        for record in target_rule_reconciliations:
+            intent = targets.get(record.target_intent_id)
+            key = (record.target_intent_id, record.asset)
+            if (
+                intent is None
+                or record.asset not in {target.asset for target in intent.targets}
+                or key in target_rule_by_intent_asset
+            ):
+                raise PreOpenIntentError(
+                    "target intent state contains invalid target-rule reconciliation evidence"
+                )
+            target_rule_by_intent_asset[key] = record
 
         self._targets.update(targets)
         self._target_by_session_asset.update(
@@ -603,8 +721,9 @@ class PreOpenTargetManager:
         self._order_by_child.update(order_by_child)
         self._processed_targets.update(processed_targets)
         self._reconciliations.extend(reconciliations)
+        self._target_rule_reconciliations.extend(target_rule_reconciliations)
+        self._target_rule_by_intent_asset.update(target_rule_by_intent_asset)
         self._latest_reconciliation.update(latest_reconciliation)
-        self._rule_activations.update(rule_activations)
         self._terminal_children.update(latest_reconciliation)
         self._active_rule_policy_by_asset.update(state.get("active_rule_policy_by_asset", {}))
         self._installed_rule_by_asset.update(
@@ -887,47 +1006,83 @@ class PreOpenTargetManager:
         magnitude = math.floor(abs(value) + 0.5)
         return math.copysign(float(magnitude), value)
 
-    def _activate_rules(
+    def _policy_id_for_asset(
         self,
         intent: CanonicalTargetIntent,
         asset: str,
-        timestamp: datetime,
-        filled_quantity: float,
-    ) -> datetime | None:
-        policy_id = intent.position_rule_policy_id
-        if filled_quantity <= 0:
-            return None
-        child_intent_id = f"{intent.intent_id}:{asset}"
-        existing_activation = self._rule_activations.get(child_intent_id)
-        if existing_activation is not None:
-            return existing_activation
-        position = self.broker.get_position(asset)
-        if position is None:
-            self._clear_target_managed_rule(asset)
-            return None
-        if policy_id is None:
-            self._clear_target_managed_rule(asset)
-            return None
-        rules = self._position_rules.get(policy_id)
-        if rules is None:
-            raise UnsupportedPreOpenPolicyError(
-                f"position rule policy {policy_id!r} has no registered implementation"
-            )
-        activated_at = self._as_utc(timestamp)
-        position.context.update(
-            {
-                "rule_activation_time": activated_at.isoformat(),
-                "rule_activation_bar_index": self.market.bar_index,
-                "bar_path_policy": self.policy.bar_path,
-                "position_rule_policy_id": policy_id,
-            }
+    ) -> str | None:
+        target_level_mode = any(
+            target.position_rule_policy_id is not None for target in intent.targets
         )
-        installed_rules = copy.deepcopy(rules)
-        self.broker.set_position_rules(installed_rules, asset=asset)
-        self._active_rule_policy_by_asset[asset] = policy_id
-        self._installed_rule_by_asset[asset] = installed_rules
-        self._rule_activations[child_intent_id] = activated_at
-        return activated_at
+        if target_level_mode:
+            return next(
+                target.position_rule_policy_id for target in intent.targets if target.asset == asset
+            )
+        return intent.position_rule_policy_id
+
+    def _reconcile_target_rules(
+        self,
+        intent: CanonicalTargetIntent,
+        timestamp: datetime,
+    ) -> None:
+        event_time = self._as_utc(timestamp)
+        for target in sorted(intent.targets, key=lambda item: item.asset):
+            key = (intent.intent_id, target.asset)
+            if key in self._target_rule_by_intent_asset:
+                continue
+            requested_policy_id = self._policy_id_for_asset(intent, target.asset)
+            prior_policy_id = self._active_rule_policy_by_asset.get(target.asset)
+            position = self.broker.get_position(target.asset)
+            activated_at: datetime | None = None
+            if position is None:
+                self._clear_target_managed_rule(target.asset)
+                resulting_policy_id = None
+                outcome = TargetRuleOutcome.NO_POSITION
+            elif requested_policy_id is None:
+                self._clear_target_managed_rule(target.asset)
+                resulting_policy_id = None
+                outcome = TargetRuleOutcome.CLEARED
+            elif requested_policy_id == prior_policy_id:
+                resulting_policy_id = prior_policy_id
+                outcome = TargetRuleOutcome.PRESERVED
+                activation_value = position.context.get("rule_activation_time")
+                if isinstance(activation_value, str):
+                    activated_at = datetime.fromisoformat(activation_value)
+            else:
+                rules = self._position_rules.get(requested_policy_id)
+                if rules is None:
+                    raise UnsupportedPreOpenPolicyError(
+                        f"position rule policy {requested_policy_id!r} has no registered "
+                        "implementation"
+                    )
+                self._clear_target_managed_rule(target.asset)
+                activated_at = event_time
+                position.context.update(
+                    {
+                        "rule_activation_time": activated_at.isoformat(),
+                        "rule_activation_bar_index": self.market.bar_index,
+                        "bar_path_policy": self.policy.bar_path,
+                        "position_rule_policy_id": requested_policy_id,
+                    }
+                )
+                installed_rules = copy.deepcopy(rules)
+                self.broker.set_position_rules(installed_rules, asset=target.asset)
+                self._active_rule_policy_by_asset[target.asset] = requested_policy_id
+                self._installed_rule_by_asset[target.asset] = installed_rules
+                resulting_policy_id = requested_policy_id
+                outcome = TargetRuleOutcome.ACTIVATED
+            record = TargetRuleReconciliation(
+                target_intent_id=intent.intent_id,
+                asset=target.asset,
+                event_time=event_time,
+                requested_policy_id=requested_policy_id,
+                prior_policy_id=prior_policy_id,
+                resulting_policy_id=resulting_policy_id,
+                outcome=outcome,
+                activated_at=activated_at,
+            )
+            self._target_rule_reconciliations.append(record)
+            self._target_rule_by_intent_asset[key] = record
 
     def _clear_rules_for_flat_positions(self) -> None:
         for asset in tuple(self._active_rule_policy_by_asset):

--- a/src/ml4t/backtest/result.py
+++ b/src/ml4t/backtest/result.py
@@ -647,9 +647,13 @@ class BacktestResult:
             "target_intent_count": self.metrics.get("target_intent_count", 0),
             "child_order_intent_count": self.metrics.get("child_order_intent_count", 0),
             "intent_reconciliation_count": self.metrics.get("intent_reconciliation_count", 0),
+            "target_rule_reconciliation_count": self.metrics.get(
+                "target_rule_reconciliation_count", 0
+            ),
             "target_intents": self.metrics.get("target_intents", []),
             "child_order_intents": self.metrics.get("child_order_intents", []),
             "intent_reconciliations": self.metrics.get("intent_reconciliations", []),
+            "target_rule_reconciliations": self.metrics.get("target_rule_reconciliations", []),
             "config": config_dict,
             "window": {
                 "start": start,

--- a/tests/compatibility/snapshots/v0.1.json
+++ b/tests/compatibility/snapshots/v0.1.json
@@ -558,6 +558,7 @@
     "from ml4t.backtest import BacktestConfig",
     "from ml4t.backtest import BacktestConfig, CommissionType",
     "from ml4t.backtest import BacktestConfig, DataFeed",
+    "from ml4t.backtest import BacktestConfig, DataFeed, Engine, Strategy",
     "from ml4t.backtest import BacktestConfig, Engine",
     "from ml4t.backtest import Broker, BacktestConfig",
     "from ml4t.backtest import DataFeed",

--- a/tests/compatibility/snapshots/v0.1.json
+++ b/tests/compatibility/snapshots/v0.1.json
@@ -614,6 +614,7 @@
     "from ml4t.backtest.risk.position import AnyOf",
     "from ml4t.backtest.risk.position import ScaledExit",
     "from ml4t.backtest.risk.position import SignalExit",
+    "from ml4t.backtest.risk.position import StopLoss, TrailingStop",
     "from ml4t.backtest.risk.position import TighteningTrailingStop",
     "from ml4t.backtest.risk.position import TimeExit",
     "from ml4t.backtest.risk.position import VolatilityStop",
@@ -1097,6 +1098,8 @@
       "sortino",
       "target_intent_count",
       "target_intents",
+      "target_rule_reconciliation_count",
+      "target_rule_reconciliations",
       "total_commission",
       "total_costs",
       "total_filled_notional",
@@ -1862,6 +1865,8 @@
     "IntentReconciliation",
     "LateAuctionIntentError",
     "PreOpenIntentError",
+    "TargetRuleOutcome",
+    "TargetRuleReconciliation",
     "UnsupportedPreOpenPolicyError",
     "default_execution_policy",
     "StopLoss",
@@ -2955,6 +2960,22 @@
       "qualname": "SignalExit",
       "signature": "(signal_name: str = 'exit_signal', threshold: float = 0.0) -> None"
     },
+    "ml4t.backtest.risk.position:StopLoss": {
+      "kind": "class",
+      "members": {
+        "__repr__": {
+          "kind": "method",
+          "signature": "(self)"
+        },
+        "evaluate": {
+          "kind": "method",
+          "signature": "(self, state: ml4t.backtest.risk.types.PositionState) -> ml4t.backtest.risk.types.PositionAction"
+        }
+      },
+      "module": "ml4t.backtest.risk.position.static",
+      "qualname": "StopLoss",
+      "signature": "(pct: float) -> None"
+    },
     "ml4t.backtest.risk.position:TakeProfit": {
       "kind": "class",
       "members": {
@@ -3002,6 +3023,22 @@
       "module": "ml4t.backtest.risk.position.static",
       "qualname": "TimeExit",
       "signature": "(max_bars: int) -> None"
+    },
+    "ml4t.backtest.risk.position:TrailingStop": {
+      "kind": "class",
+      "members": {
+        "__repr__": {
+          "kind": "method",
+          "signature": "(self)"
+        },
+        "evaluate": {
+          "kind": "method",
+          "signature": "(self, state: ml4t.backtest.risk.types.PositionState) -> ml4t.backtest.risk.types.PositionAction"
+        }
+      },
+      "module": "ml4t.backtest.risk.position.dynamic",
+      "qualname": "TrailingStop",
+      "signature": "(pct: float) -> None"
     },
     "ml4t.backtest.risk.position:VolatilityStop": {
       "kind": "class",
@@ -3489,6 +3526,10 @@
           "kind": "method",
           "signature": "(self) -> 'tuple[CanonicalTargetIntent, ...]'"
         },
+        "get_target_rule_reconciliations": {
+          "kind": "method",
+          "signature": "(self) -> 'tuple[TargetRuleReconciliation, ...]'"
+        },
         "get_trades": {
           "kind": "method",
           "signature": "(self, asset: 'str | None' = None, last_n: 'int | None' = None) -> 'list[Trade]'"
@@ -3535,7 +3576,7 @@
         },
         "register_target_intent": {
           "kind": "method",
-          "signature": "(self, intent: 'CanonicalTargetIntent', *, position_rules: 'PositionRule | None' = None) -> 'CanonicalTargetIntent'"
+          "signature": "(self, intent: 'CanonicalTargetIntent', *, position_rules: 'PositionRule | Mapping[str, PositionRule] | None' = None) -> 'CanonicalTargetIntent'"
         },
         "restore_target_intent_state": {
           "kind": "method",
@@ -3991,6 +4032,33 @@
       "module": "ml4t.backtest.risk.position.static",
       "qualname": "TakeProfit",
       "signature": "(pct: float) -> None"
+    },
+    "ml4t.backtest:TargetRuleOutcome": {
+      "kind": "class",
+      "members": {},
+      "module": "ml4t.backtest.preopen",
+      "qualname": "TargetRuleOutcome",
+      "signature": "(*values)"
+    },
+    "ml4t.backtest:TargetRuleReconciliation": {
+      "kind": "class",
+      "members": {
+        "__repr__": {
+          "kind": "method",
+          "signature": "(self)"
+        },
+        "from_mapping": {
+          "kind": "method",
+          "signature": "(cls, value: 'dict[str, Any]') -> 'TargetRuleReconciliation'"
+        },
+        "to_dict": {
+          "kind": "method",
+          "signature": "(self) -> 'dict[str, Any]'"
+        }
+      },
+      "module": "ml4t.backtest.preopen",
+      "qualname": "TargetRuleReconciliation",
+      "signature": "(target_intent_id: 'str', asset: 'str', event_time: 'datetime', requested_policy_id: 'str | None', prior_policy_id: 'str | None', resulting_policy_id: 'str | None', outcome: 'TargetRuleOutcome', activated_at: 'datetime | None' = None) -> None"
     },
     "ml4t.backtest:TargetWeightExecutor": {
       "kind": "class",

--- a/tests/contracts/test_python_support_policy.py
+++ b/tests/contracts/test_python_support_policy.py
@@ -111,7 +111,7 @@ def test_minimum_dependency_matrix_proves_declared_lower_bounds() -> None:
         if (requirement := Requirement(dependency)).name == "ml4t-specs"
     ]
     assert len(specs_dependencies) == 1
-    assert str(specs_dependencies[0].specifier) == "<0.2,>=0.1.1"
+    assert str(specs_dependencies[0].specifier) == "<0.2,>=0.1.2"
     assert specs_dependencies[0].url is None
 
 

--- a/tests/test_preopen_intents.py
+++ b/tests/test_preopen_intents.py
@@ -32,6 +32,7 @@ from ml4t.backtest import (
     Position,
     PreOpenIntentError,
     Strategy,
+    TargetRuleOutcome,
     UnsupportedPreOpenPolicyError,
     default_execution_policy,
 )
@@ -166,6 +167,7 @@ def test_target_intent_api_requires_an_engine_configured_broker() -> None:
     assert broker.get_target_intents() == ()
     assert broker.get_child_order_intents() == ()
     assert broker.get_intent_reconciliations() == ()
+    assert broker.get_target_rule_reconciliations() == ()
     assert broker.export_target_intent_state() == {}
     with pytest.raises(RuntimeError, match="Engine-configured broker"):
         broker.register_target_intent(target_intent())
@@ -314,7 +316,42 @@ def test_failed_prepare_rolls_back_target_and_position_rule_registration() -> No
     assert engine.broker.get_target_intents() == ()
     assert engine.broker.get_child_order_intents() == ()
     assert engine.broker.get_intent_reconciliations() == ()
+    assert engine.broker.get_target_rule_reconciliations() == ()
     assert engine.preopen_target_manager._position_rules == {}
+
+
+def test_failed_prepare_rolls_back_all_target_level_policy_registrations() -> None:
+    intent = portfolio_intent(
+        "rollback",
+        date(2026, 8, 3),
+        (("SPY", 0.5, "stop-5"), ("QQQ", 0.5, "trail-5")),
+    )
+
+    class FailingPrepare(Strategy):
+        def on_prepare(self, broker, config=None) -> None:
+            broker.register_target_intent(
+                intent,
+                position_rules={
+                    "stop-5": StopLoss(0.05),
+                    "trail-5": TrailingStop(0.05),
+                },
+            )
+            raise RuntimeError("prepare failed")
+
+        def on_data(self, timestamp, data, context, broker) -> None:
+            return None
+
+    engine = Engine(
+        DataFeed(prices_df=portfolio_prices((date(2026, 8, 3),), ("SPY", "QQQ"))),
+        FailingPrepare(),
+    )
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        engine.run()
+
+    assert engine.broker.get_target_intents() == ()
+    assert engine.preopen_target_manager._position_rules == {}
+    assert engine.broker.get_target_rule_reconciliations() == ()
 
 
 def test_callback_rollback_does_not_run_public_restart_validation(
@@ -760,7 +797,11 @@ def test_one_target_intent_activates_distinct_asset_rule_policies_on_entry_bar()
     result = engine.run()
 
     assert engine.broker.get_target_intents() == (intent,)
-    assert {trade.exit_reason for trade in result.trades} == {"stop_loss", "trailing_stop"}
+    assert {trade.symbol: trade.exit_reason for trade in result.trades} == {
+        "IWM": "end_of_backtest",
+        "QQQ": "trailing_stop",
+        "SPY": "stop_loss",
+    }
     assert engine.broker.get_position("IWM") is not None
     assert "IWM" not in engine.broker._position_rules_by_asset
     assert [record.asset for record in engine.broker.get_target_rule_reconciliations()] == [
@@ -829,6 +870,139 @@ def test_unchanged_carried_position_preserves_replaces_and_clears_rule_policy() 
     ]
 
 
+def test_partial_liquidation_applies_changed_policy_to_remaining_position() -> None:
+    sessions = (date(2026, 8, 3), date(2026, 8, 4))
+    intents = (
+        portfolio_intent("enter", sessions[0], (("SPY", 0.5, "stop-50"),)),
+        portfolio_intent("trim", sessions[1], (("SPY", 0.0, "stop-20"),)),
+    )
+    feed = portfolio_prices(
+        sessions,
+        ("SPY",),
+        overrides={
+            (sessions[0], "SPY"): {"volume": 5_000.0},
+            (sessions[1], "SPY"): {"volume": 100.0},
+        },
+    )
+    config = BacktestConfig()
+    policy = replace(
+        default_execution_policy(config),
+        liquidity_fraction=0.1,
+        allow_partial_fills=True,
+    )
+
+    class PartialRuleStrategy(Strategy):
+        def on_prepare(self, broker, config=None) -> None:
+            broker.register_target_intent(intents[0], position_rules={"stop-50": StopLoss(0.5)})
+            broker.register_target_intent(intents[1], position_rules={"stop-20": StopLoss(0.2)})
+
+        def on_data(self, timestamp, data, context, broker) -> None:
+            return None
+
+    engine = Engine(
+        DataFeed(prices_df=feed),
+        PartialRuleStrategy(),
+        config,
+        execution_policy=policy,
+    )
+
+    engine.run()
+
+    position = engine.broker.get_position("SPY")
+    assert position is not None
+    assert position.quantity == 490
+    assert engine.broker._position_rules_by_asset["SPY"] == StopLoss(0.2)
+    assert [record.outcome for record in engine.broker.get_intent_reconciliations()] == [
+        IntentOutcome.FULL,
+        IntentOutcome.PARTIAL,
+    ]
+    assert [
+        record.resulting_policy_id for record in engine.broker.get_target_rule_reconciliations()
+    ] == ["stop-50", "stop-20"]
+
+
+def test_rejected_reversal_applies_changed_policy_to_carried_position() -> None:
+    sessions = (date(2026, 8, 3), date(2026, 8, 4))
+    intents = (
+        portfolio_intent("enter", sessions[0], (("SPY", 0.5, "stop-50"),)),
+        portfolio_intent("rejected", sessions[1], (("SPY", -0.5, "stop-20"),)),
+    )
+
+    class RejectedRuleStrategy(Strategy):
+        def on_prepare(self, broker, config=None) -> None:
+            broker.register_target_intent(intents[0], position_rules={"stop-50": StopLoss(0.5)})
+            broker.register_target_intent(intents[1], position_rules={"stop-20": StopLoss(0.2)})
+
+        def on_data(self, timestamp, data, context, broker) -> None:
+            return None
+
+    engine = Engine(
+        DataFeed(prices_df=portfolio_prices(sessions, ("SPY",))),
+        RejectedRuleStrategy(),
+    )
+
+    engine.run()
+
+    position = engine.broker.get_position("SPY")
+    assert position is not None
+    assert position.quantity == 500
+    assert engine.broker.get_intent_reconciliations()[-1].outcome is IntentOutcome.REJECTED
+    rule_record = engine.broker.get_target_rule_reconciliations()[-1]
+    assert rule_record.prior_policy_id == "stop-50"
+    assert rule_record.resulting_policy_id == "stop-20"
+    assert rule_record.outcome is TargetRuleOutcome.ACTIVATED
+    assert engine.broker._position_rules_by_asset["SPY"] == StopLoss(0.2)
+
+
+def test_failed_new_entry_records_no_position_and_does_not_activate_rule() -> None:
+    session = date(2026, 8, 3)
+    intent = portfolio_intent("rejected", session, (("SPY", -0.5, "stop-20"),))
+    engine = Engine(
+        DataFeed(prices_df=portfolio_prices((session,), ("SPY",))),
+        InitialTargetStrategy(intent, {"stop-20": StopLoss(0.2)}),
+    )
+
+    engine.run()
+
+    assert engine.broker.get_position("SPY") is None
+    assert "SPY" not in engine.broker._position_rules_by_asset
+    rule_record = engine.broker.get_target_rule_reconciliations()[0]
+    assert rule_record.outcome is TargetRuleOutcome.NO_POSITION
+    assert rule_record.requested_policy_id == "stop-20"
+    assert rule_record.resulting_policy_id is None
+    assert rule_record.activated_at is None
+
+
+def test_full_liquidation_clears_target_managed_rule_and_records_no_position() -> None:
+    sessions = (date(2026, 8, 3), date(2026, 8, 4))
+    intents = (
+        portfolio_intent("enter", sessions[0], (("SPY", 0.5, "stop-50"),)),
+        portfolio_intent("exit", sessions[1], (("SPY", 0.0, None),)),
+    )
+
+    class LiquidatingRuleStrategy(Strategy):
+        def on_prepare(self, broker, config=None) -> None:
+            broker.register_target_intent(intents[0], position_rules={"stop-50": StopLoss(0.5)})
+            broker.register_target_intent(intents[1])
+
+        def on_data(self, timestamp, data, context, broker) -> None:
+            return None
+
+    engine = Engine(
+        DataFeed(prices_df=portfolio_prices(sessions, ("SPY",))),
+        LiquidatingRuleStrategy(),
+    )
+
+    engine.run()
+
+    assert engine.broker.get_position("SPY") is None
+    assert "SPY" not in engine.broker._position_rules_by_asset
+    record = engine.broker.get_target_rule_reconciliations()[-1]
+    assert record.prior_policy_id == "stop-50"
+    assert record.resulting_policy_id is None
+    assert record.outcome is TargetRuleOutcome.NO_POSITION
+
+
 @pytest.mark.parametrize(
     ("position_rules", "message"),
     [
@@ -893,6 +1067,36 @@ def test_conflicting_target_level_policy_registration_is_atomic() -> None:
         manager._idempotency,
         manager._position_rules,
     ) == before
+
+
+def test_target_level_policy_registration_supports_prebinding_and_idempotent_reattachment() -> None:
+    intent = portfolio_intent(
+        "idempotent",
+        date(2026, 8, 3),
+        (("SPY", 0.5, "stop-5"), ("QQQ", 0.5, "trail-5")),
+    )
+    engine = Engine(
+        DataFeed(prices_df=portfolio_prices((date(2026, 8, 3),), ("SPY", "QQQ"))),
+        NoOpStrategy(),
+    )
+    manager = engine.preopen_target_manager
+    manager.register_position_rule_policy("stop-5", StopLoss(0.05))
+
+    accepted = manager.register(
+        intent,
+        position_rules={"trail-5": TrailingStop(0.05)},
+    )
+    repeated = manager.register(
+        intent,
+        position_rules={
+            "stop-5": StopLoss(0.05),
+            "trail-5": TrailingStop(0.05),
+        },
+    )
+
+    assert repeated is accepted
+    assert manager.targets == (intent,)
+    assert set(manager._position_rules) == {"stop-5", "trail-5"}
 
 
 def test_target_managed_rule_does_not_apply_after_flat_and_plain_reentry() -> None:
@@ -1162,6 +1366,7 @@ def test_terminal_reconciliation_is_not_duplicated_on_later_bars() -> None:
     assert len(reconciliations) == 1
     assert reconciliations[0].outcome is IntentOutcome.PARTIAL
     assert reconciliations[0].remaining_quantity == 490
+    assert len(engine.broker.get_target_rule_reconciliations()) == 1
 
 
 def test_percentage_fees_are_reserved_during_opening_weight_sizing() -> None:
@@ -1397,6 +1602,7 @@ def test_restart_registration_reattaches_position_rule_implementation() -> None:
 
     restored.restore_state(state)
     assert restored.register(intent, position_rules=StopLoss(0.05)) is restored.targets[0]
+    assert restored.target_rule_reconciliations == engine.broker.get_target_rule_reconciliations()
 
 
 def test_restored_manager_preserves_an_explicit_rule_disable_during_cleanup() -> None:
@@ -1438,6 +1644,14 @@ def test_result_artifact_round_trip_retains_contract_and_intent_evidence(tmp_pat
     assert loaded.metrics["target_intents"] == [intent.to_dict()]
     assert loaded.metrics["child_order_intents"] == result.metrics["child_order_intents"]
     assert loaded.metrics["intent_reconciliations"] == result.metrics["intent_reconciliations"]
+    assert (
+        loaded.metrics["target_rule_reconciliations"]
+        == result.metrics["target_rule_reconciliations"]
+    )
+    assert (
+        loaded.to_spec_dict()["target_rule_reconciliations"]
+        == result.to_spec_dict()["target_rule_reconciliations"]
+    )
 
 
 def test_default_result_retains_intent_counts_without_full_history(tmp_path) -> None:
@@ -1449,9 +1663,11 @@ def test_default_result_retains_intent_counts_without_full_history(tmp_path) -> 
     assert result.metrics["target_intent_count"] == 1
     assert result.metrics["child_order_intent_count"] == 1
     assert result.metrics["intent_reconciliation_count"] == 1
+    assert result.metrics["target_rule_reconciliation_count"] == 1
     assert result.metrics["target_intents"] == []
     assert result.metrics["child_order_intents"] == []
     assert result.metrics["intent_reconciliations"] == []
+    assert result.metrics["target_rule_reconciliations"] == []
     assert result.to_spec_dict()["target_intent_count"] == 1
 
     result.to_parquet(tmp_path)
@@ -1459,6 +1675,7 @@ def test_default_result_retains_intent_counts_without_full_history(tmp_path) -> 
     assert loaded.metrics["target_intent_count"] == 1
     assert loaded.metrics["child_order_intent_count"] == 1
     assert loaded.metrics["intent_reconciliation_count"] == 1
+    assert loaded.metrics["target_rule_reconciliation_count"] == 1
 
 
 def test_ambiguous_opening_bar_path_requires_declared_resolution() -> None:

--- a/tests/test_preopen_intents.py
+++ b/tests/test_preopen_intents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import fields, replace
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 
 import polars as pl
 import pytest
@@ -89,6 +89,60 @@ def target_intent(
     )
 
 
+def portfolio_intent(
+    intent_id: str,
+    session: date,
+    targets: tuple[tuple[str, float, str | None], ...],
+) -> CanonicalTargetIntent:
+    decision_time = datetime.combine(session, datetime.min.time(), tzinfo=UTC) - timedelta(hours=1)
+    return CanonicalTargetIntent(
+        intent_id=intent_id,
+        decision_time=decision_time,
+        information_cutoff=decision_time,
+        effective_session=session,
+        effective_phase=LifecyclePhase.PRE_OPEN,
+        targets=tuple(
+            AssetTarget(
+                asset,
+                TargetMeasure.WEIGHT,
+                weight,
+                position_rule_policy_id=policy_id,
+            )
+            for asset, weight, policy_id in targets
+        ),
+        idempotency_key=f"{intent_id}-key",
+        measure=TargetMeasure.WEIGHT,
+        cash_buffer=0.0,
+        rounding=RoundingPolicy.TOWARD_ZERO,
+        residual=ResidualPolicy.KEEP_CASH,
+        reason=IntentReason.REBALANCE,
+    )
+
+
+def portfolio_prices(
+    sessions: tuple[date, ...],
+    assets: tuple[str, ...],
+    *,
+    overrides: dict[tuple[date, str], dict[str, float]] | None = None,
+) -> pl.DataFrame:
+    overrides = overrides or {}
+    rows = []
+    for session in sessions:
+        for asset in assets:
+            row = {
+                "timestamp": datetime.combine(session, datetime.min.time()),
+                "asset": asset,
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.0,
+                "volume": 1_000_000.0,
+            }
+            row.update(overrides.get((session, asset), {}))
+            rows.append(row)
+    return pl.DataFrame(rows)
+
+
 class InitialTargetStrategy(Strategy):
     def __init__(self, intent: CanonicalTargetIntent, rules=None) -> None:
         self.intent = intent
@@ -97,6 +151,11 @@ class InitialTargetStrategy(Strategy):
     def on_prepare(self, broker, config=None) -> None:
         broker.register_target_intent(self.intent, position_rules=self.rules)
 
+    def on_data(self, timestamp, data, context, broker) -> None:
+        return None
+
+
+class NoOpStrategy(Strategy):
     def on_data(self, timestamp, data, context, broker) -> None:
         return None
 
@@ -657,6 +716,183 @@ def test_later_target_without_a_rule_policy_clears_the_target_managed_rule() -> 
     assert "position_rule_policy_id" not in position.context
     reconciliations = engine.broker.get_intent_reconciliations()
     assert [record.rule_policy_id for record in reconciliations] == ["stop-50", None]
+
+
+def test_one_target_intent_activates_distinct_asset_rule_policies_on_entry_bar() -> None:
+    session = date(2026, 8, 3)
+    intent = portfolio_intent(
+        "mixed-book",
+        session,
+        (
+            ("SPY", 0.25, "stop-5"),
+            ("QQQ", 0.25, "trail-5"),
+            ("IWM", 0.25, None),
+        ),
+    )
+    feed = portfolio_prices(
+        (session,),
+        ("SPY", "QQQ", "IWM"),
+        overrides={
+            (session, "SPY"): {"high": 102.0, "low": 94.0},
+            (session, "QQQ"): {"high": 110.0, "low": 100.0, "close": 105.0},
+        },
+    )
+
+    class MixedRuleStrategy(Strategy):
+        def on_prepare(self, broker, config=None) -> None:
+            broker.register_target_intent(
+                intent,
+                position_rules={
+                    "stop-5": StopLoss(0.05),
+                    "trail-5": TrailingStop(0.05),
+                },
+            )
+
+        def on_data(self, timestamp, data, context, broker) -> None:
+            return None
+
+    engine = Engine(
+        DataFeed(prices_df=feed),
+        MixedRuleStrategy(),
+        BacktestConfig(retain_intent_history=True),
+    )
+
+    result = engine.run()
+
+    assert engine.broker.get_target_intents() == (intent,)
+    assert {trade.exit_reason for trade in result.trades} == {"stop_loss", "trailing_stop"}
+    assert engine.broker.get_position("IWM") is not None
+    assert "IWM" not in engine.broker._position_rules_by_asset
+    assert [record.asset for record in engine.broker.get_target_rule_reconciliations()] == [
+        "IWM",
+        "QQQ",
+        "SPY",
+    ]
+
+
+def test_unchanged_carried_position_preserves_replaces_and_clears_rule_policy() -> None:
+    sessions = tuple(date(2026, 8, day) for day in range(3, 7))
+    intents = (
+        portfolio_intent("initial", sessions[0], (("SPY", 0.5, "stop-50"),)),
+        portfolio_intent("preserve", sessions[1], (("SPY", 0.5, "stop-50"),)),
+        portfolio_intent("replace", sessions[2], (("SPY", 0.5, "stop-20"),)),
+        portfolio_intent("clear", sessions[3], (("SPY", 0.5, None),)),
+    )
+
+    class CarriedRuleStrategy(Strategy):
+        def __init__(self) -> None:
+            self.snapshots = []
+
+        def on_prepare(self, broker, config=None) -> None:
+            broker.register_target_intent(intents[0], position_rules={"stop-50": StopLoss(0.5)})
+            broker.register_target_intent(intents[1], position_rules={"stop-50": StopLoss(0.5)})
+            broker.register_target_intent(intents[2], position_rules={"stop-20": StopLoss(0.2)})
+            broker.register_target_intent(intents[3])
+
+        def on_data(self, timestamp, data, context, broker) -> None:
+            position = broker.get_position("SPY")
+            assert position is not None
+            self.snapshots.append(
+                (
+                    broker._get_position_rule_override("SPY"),
+                    dict(position.context),
+                )
+            )
+
+    strategy = CarriedRuleStrategy()
+    engine = Engine(
+        DataFeed(prices_df=portfolio_prices(sessions, ("SPY",))),
+        strategy,
+        BacktestConfig(retain_intent_history=True),
+    )
+
+    engine.run()
+
+    assert len(engine.broker.get_child_order_intents()) == 1
+    assert strategy.snapshots[0][0] is strategy.snapshots[1][0]
+    assert strategy.snapshots[2][0] is not strategy.snapshots[1][0]
+    assert strategy.snapshots[3][0] is None
+    assert (
+        strategy.snapshots[0][1]["rule_activation_time"]
+        == strategy.snapshots[1][1]["rule_activation_time"]
+    )
+    assert (
+        strategy.snapshots[2][1]["rule_activation_time"]
+        != strategy.snapshots[1][1]["rule_activation_time"]
+    )
+    assert "rule_activation_time" not in strategy.snapshots[3][1]
+    assert [record.outcome.value for record in engine.broker.get_target_rule_reconciliations()] == [
+        "activated",
+        "preserved",
+        "activated",
+        "cleared",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("position_rules", "message"),
+    [
+        (None, "no registered implementation"),
+        (
+            {"stop-5": StopLoss(0.05), "unused": StopLoss(0.1)},
+            "unreferenced.*unused",
+        ),
+    ],
+)
+def test_target_level_policy_registration_rejects_atomically(
+    position_rules,
+    message: str,
+) -> None:
+    intent = portfolio_intent(
+        "atomic",
+        date(2026, 8, 3),
+        (("SPY", 0.5, "stop-5"),),
+    )
+    engine = Engine(DataFeed(prices_df=prices(low=100.0)), NoOpStrategy())
+    manager = engine.preopen_target_manager
+    before = (
+        dict(manager._targets),
+        dict(manager._target_by_session_asset),
+        dict(manager._idempotency),
+        dict(manager._position_rules),
+    )
+
+    with pytest.raises(PreOpenIntentError, match=message):
+        manager.register(intent, position_rules=position_rules)
+
+    assert (
+        manager._targets,
+        manager._target_by_session_asset,
+        manager._idempotency,
+        manager._position_rules,
+    ) == before
+
+
+def test_conflicting_target_level_policy_registration_is_atomic() -> None:
+    intent = portfolio_intent(
+        "conflict",
+        date(2026, 8, 3),
+        (("SPY", 0.5, "stop-5"),),
+    )
+    engine = Engine(DataFeed(prices_df=prices(low=100.0)), NoOpStrategy())
+    manager = engine.preopen_target_manager
+    manager.register_position_rule_policy("stop-5", StopLoss(0.05))
+    before = (
+        dict(manager._targets),
+        dict(manager._target_by_session_asset),
+        dict(manager._idempotency),
+        dict(manager._position_rules),
+    )
+
+    with pytest.raises(PreOpenIntentError, match="already registered"):
+        manager.register(intent, position_rules={"stop-5": StopLoss(0.1)})
+
+    assert (
+        manager._targets,
+        manager._target_by_session_asset,
+        manager._idempotency,
+        manager._position_rules,
+    ) == before
 
 
 def test_target_managed_rule_does_not_apply_after_flat_and_plain_reentry() -> None:

--- a/tests/typing/public_api_consumer.py
+++ b/tests/typing/public_api_consumer.py
@@ -1,9 +1,18 @@
 """Representative typed use of the installed ml4t-backtest wheel."""
 
-from datetime import datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 import polars as pl
+from ml4t.specs import (
+    AssetTarget,
+    CanonicalTargetIntent,
+    IntentReason,
+    LifecyclePhase,
+    ResidualPolicy,
+    RoundingPolicy,
+    TargetMeasure,
+)
 
 from ml4t.backtest import (
     BacktestConfig,
@@ -14,6 +23,7 @@ from ml4t.backtest import (
     OrderSide,
     Strategy,
 )
+from ml4t.backtest.risk.position import StopLoss, TrailingStop
 
 
 class BuyFirstAsset(Strategy):
@@ -33,3 +43,42 @@ def run_typed_consumer(prices: pl.DataFrame) -> BacktestResult:
     feed = DataFeed(prices_df=prices)
     engine = Engine(feed=feed, strategy=BuyFirstAsset(), config=BacktestConfig())
     return engine.run()
+
+
+def register_typed_target_rules(broker: Broker) -> None:
+    decision = datetime(2026, 8, 2, 20, tzinfo=UTC)
+    intent = CanonicalTargetIntent(
+        intent_id="typed-mixed-rules",
+        decision_time=decision,
+        information_cutoff=decision,
+        effective_session=date(2026, 8, 3),
+        effective_phase=LifecyclePhase.PRE_OPEN,
+        targets=(
+            AssetTarget(
+                "SPY",
+                TargetMeasure.WEIGHT,
+                0.45,
+                position_rule_policy_id="stop-5",
+            ),
+            AssetTarget(
+                "QQQ",
+                TargetMeasure.WEIGHT,
+                0.45,
+                position_rule_policy_id="trail-8",
+            ),
+        ),
+        idempotency_key="typed-mixed-rules-2026-08-03",
+        measure=TargetMeasure.WEIGHT,
+        cash_buffer=0.1,
+        rounding=RoundingPolicy.TOWARD_ZERO,
+        residual=ResidualPolicy.KEEP_CASH,
+        reason=IntentReason.REBALANCE,
+    )
+    broker.register_target_intent(
+        intent,
+        position_rules={
+            "stop-5": StopLoss(0.05),
+            "trail-8": TrailingStop(0.08),
+        },
+    )
+    broker.get_target_rule_reconciliations()

--- a/uv.lock
+++ b/uv.lock
@@ -1902,7 +1902,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
     { name = "ml4t-diagnostic", marker = "extra == 'all'", specifier = ">=0.1.0b4" },
     { name = "ml4t-diagnostic", marker = "extra == 'dev'", specifier = ">=0.1.0b4" },
-    { name = "ml4t-specs", specifier = ">=0.1.1,<0.2" },
+    { name = "ml4t-specs", specifier = ">=0.1.2,<0.2" },
     { name = "networkx", marker = "extra == 'advanced'", specifier = ">=3.0" },
     { name = "networkx", marker = "extra == 'all'", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=2.3.2" },
@@ -2083,14 +2083,14 @@ wheels = [
 
 [[package]]
 name = "ml4t-specs"
-version = "0.1.1"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/69/f3e67230cb9f9b18f4b07f905a3dbc46f19afa172cdfed1428480b96b21c/ml4t_specs-0.1.1.tar.gz", hash = "sha256:0d807edf20f839826f04f0d3b6d14ca37ab056d2bf0b599f3c4d00f2fbd0fade", size = 50047, upload-time = "2026-08-09T18:43:40.697Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/6b/58aacbc7ccf9239edb5f3b350b418aff543f87698852e1507892c2ce8c26/ml4t_specs-0.1.2.tar.gz", hash = "sha256:72131624220bdded7d01d9c09e4c9e6637e8e977a37be283bc7f38d4fe0b1e1a", size = 50590, upload-time = "2026-08-10T00:53:01.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/9a/1f256a8b78a15a0140410c224c91464e5383680ff8108fc94b82fde5678f/ml4t_specs-0.1.1-py3-none-any.whl", hash = "sha256:97d017ed8968d77dfa52409c0817a99c15986bd3fe875c4c58fcbd9499336220", size = 33620, upload-time = "2026-08-09T18:43:39.543Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/1508cd131272885391fe17eb54865d8c2ee0a853d15bdd5cfd838b20ce44/ml4t_specs-0.1.2-py3-none-any.whl", hash = "sha256:c9e6749bc28c087f1a97494690edae94460aeffe2c223494a19c41c4915b9532", size = 33763, upload-time = "2026-08-10T00:53:00.474Z" },
 ]
 
 [[package]]

--- a/validation/check_documentation_examples.py
+++ b/validation/check_documentation_examples.py
@@ -16,8 +16,16 @@ _DEFAULT_PATHS = (
     _ROOT / "README.md",
     _ROOT / "docs" / "getting-started" / "installation.md",
     _ROOT / "docs" / "getting-started" / "quickstart.md",
+    _ROOT / "docs" / "user-guide" / "execution-semantics.md",
 )
-_REQUIRED_EXAMPLES = frozenset({"installation-import", "readme-quickstart", "quickstart-minimal"})
+_REQUIRED_EXAMPLES = frozenset(
+    {
+        "installation-import",
+        "preopen-mixed-rules",
+        "readme-quickstart",
+        "quickstart-minimal",
+    }
+)
 _EXAMPLE = re.compile(
     r"<!-- ml4t-doc-test: (?P<name>[a-z0-9-]+) -->\s*"
     r"```(?P<language>python|bash)\n(?P<code>.*?)\n```",


### PR DESCRIPTION
## Summary

- accept strict per-policy rule mappings for target-level pre-open declarations
- reconcile each asset's rule against its actual post-auction position
- preserve, replace, clear, and report target-managed rules independently per asset
- retain target-rule evidence in state and result artifacts
- document and execute a complete mixed-rule target example
- require the released `ml4t-specs>=0.1.2,<0.2`

## Verification

- `pre-commit run --all-files`
- `uv run pytest tests/ -q` (1,957 passed, 14 skipped; 86.36% coverage)
- `uv run mkdocs build --strict`
- `uv run python validation/check_documentation_examples.py`
- dependency audit and Bandit policy scan: no findings
- reproducible sdist and wheel build plus `twine check`
- hot-path and stable-release performance gates

The local Python 3.14 host cannot build the optional Zipline `tables` dependency because it has no HDF5 headers. The required cross-engine contract job runs with the repository's Python 3.12 CI environment.
