### PR TITLE
docs: point AGENTS.md at the book-guide chapter-to-API cross-reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,8 @@ Event-driven backtesting engine with cross-framework parity validation.
 ```python
 from ml4t.backtest import Engine, Strategy, BacktestConfig, run_backtest
 ```
+
+## Documentation
+
+- `docs/book-guide/index.md` maps book notebook -> concept -> `ml4t.backtest` API -> docs page.
+  Start there for chapter-to-API cross-reference instead of grepping source.


### PR DESCRIPTION
## Summary
- AGENTS.md had no pointer to the existing docs/book-guide/index.md chapter-notebook-to-API mapping, unlike ml4t-engineer and ml4t-diagnostic. Adds one line under a new Documentation section.

## Test plan
- Docs-only change; pre-commit hooks (ruff, trailing whitespace, etc.) pass.