### PR TITLE
fix: ExecutionPrice.VWAP fills at the feed's VWAP, or refuses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires-python = ">=3.12"
 
 # Core dependencies
 dependencies = [
-    "ml4t-specs>=0.1.2,<0.2",
+    "ml4t-specs>=0.1.4,<0.2",
     "polars>=1.36.1",
     "pandas>=2.3.3; python_version < '3.15'",
     "pandas>=3.0.5; python_version >= '3.15'",
@@ -252,11 +252,3 @@ exclude_lines = [
     "except ImportError:",
     "@abstractmethod",
 ]
-
-# TEMPORARY - REMOVE BEFORE MERGE.
-# FeedSpec.vwap_col lands in ml4t-specs#13 and is not released yet. Without this the
-# `ty` hook resolves FeedSpec against the published 0.1.x and rejects datafeed.py:182.
-# Once ml4t-specs is released, delete this block and raise the version floor in
-# [project.dependencies] instead. Tracked by ml4t/agent-workspace#1017.
-[tool.uv.sources]
-ml4t-specs = { git = "https://github.com/ml4t/specs.git", branch = "feat/feedspec-vwap-col" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,3 +252,11 @@ exclude_lines = [
     "except ImportError:",
     "@abstractmethod",
 ]
+
+# TEMPORARY - REMOVE BEFORE MERGE.
+# FeedSpec.vwap_col lands in ml4t-specs#13 and is not released yet. Without this the
+# `ty` hook resolves FeedSpec against the published 0.1.x and rejects datafeed.py:182.
+# Once ml4t-specs is released, delete this block and raise the version floor in
+# [project.dependencies] instead. Tracked by ml4t/agent-workspace#1017.
+[tool.uv.sources]
+ml4t-specs = { git = "https://github.com/ml4t/specs.git", branch = "feat/feedspec-vwap-col" }

--- a/src/ml4t/backtest/broker.py
+++ b/src/ml4t/backtest/broker.py
@@ -569,6 +569,14 @@ class Broker:
         self._market_state.volumes = value
 
     @property
+    def _current_vwaps(self) -> dict[str, float]:
+        return self._market_state.vwaps
+
+    @_current_vwaps.setter
+    def _current_vwaps(self, value: dict[str, float]) -> None:
+        self._market_state.vwaps = value
+
+    @property
     def _current_bids(self) -> dict[str, float]:
         return self._market_state.bids
 
@@ -968,6 +976,11 @@ class Broker:
                 ExecutionPrice.ASK,
                 ExecutionPrice.QUOTE_MID,
                 ExecutionPrice.QUOTE_SIDE,
+                # VWAP is already a whole-bar price, so the open short-circuit must not
+                # override it. While VWAP was absent from this set the branch below was
+                # unreachable under NEXT_BAR, and every VWAP fill silently returned the
+                # open - the assumption a caller chooses VWAP specifically to avoid.
+                ExecutionPrice.VWAP,
             }
         ):
             return self._current_opens.get(asset, self._current_prices.get(asset))
@@ -985,7 +998,16 @@ class Broker:
                 return (high + low) / 2.0
             return self._current_prices.get(asset, self._current_closes.get(asset))
         if source == ExecutionPrice.VWAP:
-            return self._current_prices.get(asset, self._current_closes.get(asset))
+            vwap = self._current_vwaps.get(asset)
+            if vwap is None:
+                raise ValueError(
+                    f"execution_price is VWAP but the feed carries no VWAP for {asset!r} at "
+                    f"{self._current_time}. Declare the column as FeedSpec.vwap_col. This "
+                    f"refuses rather than falling back to the close: a VWAP fill and a close "
+                    f"fill are different assumptions, and a substitution here would be "
+                    f"indistinguishable from a correct run."
+                )
+            return vwap
         if source == ExecutionPrice.BID:
             return self._current_bids.get(asset, self._current_prices.get(asset))
         if source == ExecutionPrice.ASK:
@@ -2285,6 +2307,7 @@ class Broker:
             lows = lows if lows is not None else kwargs.pop("lows", None)
             closes = kwargs.pop("closes", prices)
             volumes = kwargs.pop("volumes")
+            vwaps = kwargs.pop("vwaps", {})
             bids = kwargs.pop("bids", {})
             asks = kwargs.pop("asks", {})
             mids = kwargs.pop("mids", {})
@@ -2296,18 +2319,24 @@ class Broker:
         elif len(rest) == 2:
             volumes, signals = rest
             closes = prices
+            vwaps = {}
             bids = {}
             asks = {}
             mids = {}
             bid_sizes = {}
             ask_sizes = {}
         elif len(rest) == 8:
+            # Pre-VWAP positional form, kept working: a caller that does not pass VWAPs
+            # gets an empty cache, and get_price_for_source raises if it then asks for one.
             closes, volumes, bids, asks, mids, bid_sizes, ask_sizes, signals = rest
+            vwaps = {}
+        elif len(rest) == 9:
+            closes, volumes, vwaps, bids, asks, mids, bid_sizes, ask_sizes, signals = rest
         else:
             raise TypeError(
                 "_update_time expects either legacy arguments "
                 "(timestamp, prices, opens, highs, lows, volumes, signals) "
-                "or quote-aware arguments with closes/bid/ask caches."
+                "or quote-aware arguments with closes/vwap/bid/ask caches."
             )
         if highs is None or lows is None:
             raise TypeError("_update_time requires highs and lows")
@@ -2320,6 +2349,7 @@ class Broker:
         self._current_lows = lows
         self._current_closes = closes
         self._current_volumes = volumes
+        self._current_vwaps = vwaps
         self._current_bids = bids
         self._current_asks = asks
         self._current_mids = mids

--- a/src/ml4t/backtest/broker.py
+++ b/src/ml4t/backtest/broker.py
@@ -998,16 +998,15 @@ class Broker:
                 return (high + low) / 2.0
             return self._current_prices.get(asset, self._current_closes.get(asset))
         if source == ExecutionPrice.VWAP:
-            vwap = self._current_vwaps.get(asset)
-            if vwap is None:
-                raise ValueError(
-                    f"execution_price is VWAP but the feed carries no VWAP for {asset!r} at "
-                    f"{self._current_time}. Declare the column as FeedSpec.vwap_col. This "
-                    f"refuses rather than falling back to the close: a VWAP fill and a close "
-                    f"fill are different assumptions, and a substitution here would be "
-                    f"indistinguishable from a correct run."
-                )
-            return vwap
+            # None, not a fallback and not a raise. A bar in which nothing traded has no
+            # volume-weighted price, and that is an ordinary market state rather than an
+            # error: callers already treat None as "this asset cannot be priced on this
+            # bar" and skip it, which leaves the order unfilled and the prior position
+            # standing - what happens to a real order resting in a bar with no prints.
+            # Substituting the close would invent a price from a stale carried print.
+            # A feed that declares no VWAP column at all is a different thing entirely,
+            # and Engine rejects that configuration before the first bar.
+            return self._current_vwaps.get(asset)
         if source == ExecutionPrice.BID:
             return self._current_bids.get(asset, self._current_prices.get(asset))
         if source == ExecutionPrice.ASK:

--- a/src/ml4t/backtest/config.py
+++ b/src/ml4t/backtest/config.py
@@ -1048,6 +1048,7 @@ class BacktestConfig:
                     "low_col",
                     "close_col",
                     "volume_col",
+                    "vwap_col",
                     "bid_col",
                     "ask_col",
                     "mid_col",

--- a/src/ml4t/backtest/core/state.py
+++ b/src/ml4t/backtest/core/state.py
@@ -20,6 +20,7 @@ class MarketState:
     lows: dict[str, float] = field(default_factory=dict)
     closes: dict[str, float] = field(default_factory=dict)
     volumes: dict[str, float] = field(default_factory=dict)
+    vwaps: dict[str, float] = field(default_factory=dict)
     bids: dict[str, float] = field(default_factory=dict)
     asks: dict[str, float] = field(default_factory=dict)
     mids: dict[str, float] = field(default_factory=dict)

--- a/src/ml4t/backtest/datafeed.py
+++ b/src/ml4t/backtest/datafeed.py
@@ -29,6 +29,7 @@ class _AssetsData(dict[str, dict[str, Any]]):
         "_lows",
         "_closes",
         "_volumes",
+        "_vwaps",
         "_bids",
         "_asks",
         "_mids",
@@ -45,6 +46,7 @@ class _AssetsData(dict[str, dict[str, Any]]):
         self._lows: dict[str, Any] = {}
         self._closes: dict[str, Any] = {}
         self._volumes: dict[str, Any] = {}
+        self._vwaps: dict[str, Any] = {}
         self._bids: dict[str, Any] = {}
         self._asks: dict[str, Any] = {}
         self._mids: dict[str, Any] = {}
@@ -96,6 +98,7 @@ class DataFeed:
         low_col: str | None = None,
         close_col: str | None = None,
         volume_col: str | None = None,
+        vwap_col: str | None = None,
         bid_col: str | None = None,
         ask_col: str | None = None,
         mid_col: str | None = None,
@@ -143,6 +146,7 @@ class DataFeed:
             low_col=low_col,
             close_col=close_col,
             volume_col=volume_col,
+            vwap_col=vwap_col,
             bid_col=bid_col,
             ask_col=ask_col,
             mid_col=mid_col,
@@ -175,6 +179,7 @@ class DataFeed:
         self._low_col = self.feed_spec.low_col
         self._close_col = self.feed_spec.close_col
         self._volume_col = self.feed_spec.volume_col
+        self._vwap_col = self.feed_spec.vwap_col
         self._bid_col = self.feed_spec.bid_col
         self._ask_col = self.feed_spec.ask_col
         self._mid_col = self.feed_spec.mid_col
@@ -228,6 +233,9 @@ class DataFeed:
         )
         self._price_volume_idx = (
             price_cols.index(self._volume_col) if self._volume_col in price_cols else -1
+        )
+        self._price_vwap_idx = (
+            price_cols.index(self._vwap_col) if self._vwap_col in price_cols else -1
         )
         self._price_bid_idx = price_cols.index(self._bid_col) if self._bid_col in price_cols else -1
         self._price_ask_idx = price_cols.index(self._ask_col) if self._ask_col in price_cols else -1
@@ -363,6 +371,7 @@ class DataFeed:
         price_close_idx = self._price_close_idx
         price_price_idx = self._price_price_idx
         price_volume_idx = self._price_volume_idx
+        price_vwap_idx = self._price_vwap_idx
         price_bid_idx = self._price_bid_idx
         price_ask_idx = self._price_ask_idx
         price_mid_idx = self._price_mid_idx
@@ -380,6 +389,10 @@ class DataFeed:
                 high = row[price_high_idx] if price_high_idx >= 0 else close
                 low = row[price_low_idx] if price_low_idx >= 0 else close
                 volume = row[price_volume_idx] if price_volume_idx >= 0 else 0.0
+                # No fallback to the close. A missing VWAP stays missing so the broker can
+                # refuse a VWAP fill it cannot price, rather than substitute a different
+                # quantity that would be indistinguishable from a correct one.
+                vwap = row[price_vwap_idx] if price_vwap_idx >= 0 else None
                 bid = row[price_bid_idx] if price_bid_idx >= 0 else None
                 ask = row[price_ask_idx] if price_ask_idx >= 0 else None
                 mid = row[price_mid_idx] if price_mid_idx >= 0 else None
@@ -408,6 +421,8 @@ class DataFeed:
                     "volume": volume,
                     "signals": {},
                 }
+                if vwap is not None:
+                    assets_data[asset]["vwap"] = vwap
                 if bid is not None:
                     assets_data[asset]["bid"] = bid
                 if ask is not None:
@@ -425,6 +440,8 @@ class DataFeed:
                 assets_data._lows[asset] = low
                 assets_data._closes[asset] = close
                 assets_data._volumes[asset] = volume
+                if vwap is not None:
+                    assets_data._vwaps[asset] = vwap
                 if bid is not None:
                     assets_data._bids[asset] = bid
                 if ask is not None:

--- a/src/ml4t/backtest/engine.py
+++ b/src/ml4t/backtest/engine.py
@@ -331,6 +331,11 @@ class Engine:
             lows = getattr(assets_data, "_lows", None)
             closes = getattr(assets_data, "_closes", None)
             volumes = getattr(assets_data, "_volumes", None)
+            # Not in the None-check below: a feed with no vwap_col legitimately has no
+            # VWAP cache, and that is not a reason to take the slow rebuild path. An
+            # empty cache is the correct value; the broker refuses at fill time if a
+            # VWAP execution price is then asked for.
+            vwaps = getattr(assets_data, "_vwaps", None) or {}
             bids = getattr(assets_data, "_bids", None)
             asks = getattr(assets_data, "_asks", None)
             mids = getattr(assets_data, "_mids", None)
@@ -373,6 +378,7 @@ class Engine:
                     highs[asset] = data.get("high") if data.get("high") is not None else base_price
                     lows[asset] = data.get("low") if data.get("low") is not None else base_price
                 volumes = {a: d.get("volume", 0) for a, d in assets_data.items()}
+                vwaps = {a: d["vwap"] for a, d in assets_data.items() if d.get("vwap") is not None}
                 bids = {a: d["bid"] for a, d in assets_data.items() if d.get("bid") is not None}
                 asks = {a: d["ask"] for a, d in assets_data.items() if d.get("ask") is not None}
                 mids = {a: d["mid"] for a, d in assets_data.items() if d.get("mid") is not None}
@@ -396,6 +402,7 @@ class Engine:
                 lows,
                 closes,
                 volumes,
+                vwaps,
                 bids,
                 asks,
                 mids,

--- a/src/ml4t/backtest/engine.py
+++ b/src/ml4t/backtest/engine.py
@@ -21,7 +21,7 @@ from ml4t.specs import (
 from .analytics import EquityCurve, TradeAnalyzer
 from .analytics.metrics import calmar_ratio
 from .broker import Broker
-from .config import DataFrequency
+from .config import DataFrequency, ExecutionPrice
 from .datafeed import DataFeed
 from .lifecycle import LifecycleDispatcher
 from .preopen import default_execution_policy
@@ -112,6 +112,16 @@ class Engine:
             market_impact_model=market_impact_model,
             execution_limits=execution_limits,
         )
+        if self.broker.execution_price is ExecutionPrice.VWAP and not getattr(
+            self.feed.feed_spec, "vwap_col", None
+        ):
+            raise ValueError(
+                "execution_price is VWAP but the feed declares no VWAP column. Set "
+                "FeedSpec.vwap_col to the column holding the volume-weighted average "
+                "price. This is checked here, once, rather than at fill time: a missing "
+                "column is a configuration error, while an individual bar with no VWAP is "
+                "an ordinary no-trade bar that leaves its order unfilled."
+            )
         self.equity_curve: list[tuple[datetime, float]] = []
         self.portfolio_state: list[tuple[datetime, float, float, float, float, int]] = []
         self.lifecycle_dispatcher = LifecycleDispatcher(

--- a/tests/compatibility/snapshots/v0.1.json
+++ b/tests/compatibility/snapshots/v0.1.json
@@ -504,7 +504,8 @@
         "timestamp_col": "timestamp",
         "timestamp_semantics": null,
         "timezone": "UTC",
-        "volume_col": "volume"
+        "volume_col": "volume",
+        "vwap_col": null
       },
       "metadata": {},
       "orders": {
@@ -3670,7 +3671,7 @@
       },
       "module": "ml4t.backtest.datafeed",
       "qualname": "DataFeed",
-      "signature": "(prices_path: str | None = None, signals_path: str | None = None, context_path: str | None = None, prices_df: polars.dataframe.frame.DataFrame | None = None, signals_df: polars.dataframe.frame.DataFrame | None = None, context_df: polars.dataframe.frame.DataFrame | None = None, *, feed_spec: ml4t.specs.market_data.FeedSpec | Any | None = None, contract: ml4t.specs.market_data.FeedSpec | Any | None = None, entity_col: str | None = None, timestamp_col: str | None = None, price_col: str | None = None, open_col: str | None = None, high_col: str | None = None, low_col: str | None = None, close_col: str | None = None, volume_col: str | None = None, bid_col: str | None = None, ask_col: str | None = None, mid_col: str | None = None, bid_size_col: str | None = None, ask_size_col: str | None = None)"
+      "signature": "(prices_path: str | None = None, signals_path: str | None = None, context_path: str | None = None, prices_df: polars.dataframe.frame.DataFrame | None = None, signals_df: polars.dataframe.frame.DataFrame | None = None, context_df: polars.dataframe.frame.DataFrame | None = None, *, feed_spec: ml4t.specs.market_data.FeedSpec | Any | None = None, contract: ml4t.specs.market_data.FeedSpec | Any | None = None, entity_col: str | None = None, timestamp_col: str | None = None, price_col: str | None = None, open_col: str | None = None, high_col: str | None = None, low_col: str | None = None, close_col: str | None = None, volume_col: str | None = None, vwap_col: str | None = None, bid_col: str | None = None, ask_col: str | None = None, mid_col: str | None = None, bid_size_col: str | None = None, ask_size_col: str | None = None)"
     },
     "ml4t.backtest:Engine": {
       "kind": "class",

--- a/tests/contracts/test_broker_state_ownership.py
+++ b/tests/contracts/test_broker_state_ownership.py
@@ -29,6 +29,7 @@ FORBIDDEN_BROKER_STATE = {
     "_current_signals",
     "_current_time",
     "_current_volumes",
+    "_current_vwaps",
     "_contract_specs",
     "_completion_validators",
     "_execution_engine",

--- a/tests/contracts/test_python_support_policy.py
+++ b/tests/contracts/test_python_support_policy.py
@@ -111,7 +111,7 @@ def test_minimum_dependency_matrix_proves_declared_lower_bounds() -> None:
         if (requirement := Requirement(dependency)).name == "ml4t-specs"
     ]
     assert len(specs_dependencies) == 1
-    assert str(specs_dependencies[0].specifier) == "<0.2,>=0.1.2"
+    assert str(specs_dependencies[0].specifier) == "<0.2,>=0.1.4"
     assert specs_dependencies[0].url is None
 
 

--- a/tests/test_vwap_execution_price.py
+++ b/tests/test_vwap_execution_price.py
@@ -81,24 +81,37 @@ class TestVwapIsItsOwnPrice:
         assert position.entry_price == VWAP
 
 
-class TestARefusalRatherThanASubstitution:
-    def test_a_feed_without_a_vwap_raises(self):
+class TestANoTradeBarIsANonFill:
+    """A bar with no prints has no VWAP, and that is not an error."""
+
+    def test_a_missing_vwap_resolves_to_none_rather_than_raising(self):
+        # Measured on the NASDAQ-100: 0.24% of production symbol-minutes inside the
+        # exchange session carry no print, and every one of them would stop a run if
+        # this raised. The engine's callers already read None as "cannot be priced on
+        # this bar" and skip, which is the non-fill.
         broker = _broker()
         _advance(broker, vwaps={})
-        with pytest.raises(ValueError, match="carries no VWAP"):
-            broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL")
+        assert broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL") is None
 
-    def test_the_refusal_names_the_field_that_fixes_it(self):
+    def test_it_does_not_fall_back_to_the_close_or_the_open(self):
         broker = _broker()
         _advance(broker, vwaps={})
-        with pytest.raises(ValueError, match="vwap_col"):
-            broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL")
+        price = broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL")
+        assert price != CLOSE
+        assert price != OPEN
 
-    def test_one_asset_missing_a_vwap_does_not_silence_another(self):
+    def test_one_asset_without_a_vwap_does_not_affect_another(self):
         broker = _broker()
         _advance(broker, vwaps={"MSFT": VWAP})
-        with pytest.raises(ValueError, match="'AAPL'"):
-            broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL")
+        assert broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL") is None
+        assert broker.get_price_for_source(ExecutionPrice.VWAP, "MSFT") == VWAP
+
+    def test_an_order_on_a_no_trade_bar_does_not_fill(self):
+        broker = _broker()
+        _advance(broker, vwaps={})
+        broker.submit_order("AAPL", 10.0, OrderSide.BUY)
+        broker._process_orders()
+        assert broker.get_position("AAPL") is None
 
 
 class TestTheFeedCarriesItThrough:
@@ -140,3 +153,56 @@ class TestTheFeedCarriesItThrough:
         _timestamp, assets, _context = next(iter(feed))
         assert "vwap" not in assets["AAPL"]
         assert assets._vwaps == {}
+
+
+class TestAnUndeclaredColumnIsAConfigurationError:
+    """A feed with no VWAP column at all is rejected once, before the first bar."""
+
+    @staticmethod
+    def _engine(feed, config):
+        from ml4t.backtest import Engine
+        from ml4t.backtest.strategy import Strategy
+
+        class _Noop(Strategy):
+            def on_data(self, timestamp, data, broker):
+                return None
+
+        return Engine(feed, _Noop(), config)
+
+    @staticmethod
+    def _prices(with_vwap: bool) -> pl.DataFrame:
+        frame = {
+            "timestamp": [datetime(2024, 1, 2, 9, 31), datetime(2024, 1, 2, 9, 32)],
+            "symbol": ["AAPL", "AAPL"],
+            "open": [OPEN, OPEN],
+            "high": [105.0, 105.0],
+            "low": [95.0, 95.0],
+            "close": [CLOSE, CLOSE],
+            "volume": [1_000_000.0, 1_000_000.0],
+        }
+        if with_vwap:
+            frame["vwap"] = [VWAP, VWAP]
+        return pl.DataFrame(frame)
+
+    def test_engine_rejects_vwap_execution_on_a_feed_without_the_column(self):
+        from ml4t.backtest.config import BacktestConfig
+
+        feed = DataFeed(prices_df=self._prices(with_vwap=False), entity_col="symbol")
+        config = BacktestConfig(execution_price=ExecutionPrice.VWAP)
+        with pytest.raises(ValueError, match="declares no VWAP column"):
+            self._engine(feed, config)
+
+    def test_engine_accepts_it_once_the_column_is_declared(self):
+        from ml4t.backtest.config import BacktestConfig
+
+        feed = DataFeed(
+            prices_df=self._prices(with_vwap=True), entity_col="symbol", vwap_col="vwap"
+        )
+        config = BacktestConfig(execution_price=ExecutionPrice.VWAP)
+        self._engine(feed, config)  # does not raise
+
+    def test_a_feed_without_the_column_is_fine_under_another_execution_price(self):
+        from ml4t.backtest.config import BacktestConfig
+
+        feed = DataFeed(prices_df=self._prices(with_vwap=False), entity_col="symbol")
+        self._engine(feed, BacktestConfig(execution_price=ExecutionPrice.CLOSE))

--- a/tests/test_vwap_execution_price.py
+++ b/tests/test_vwap_execution_price.py
@@ -1,0 +1,142 @@
+"""``ExecutionPrice.VWAP`` fills at the feed's VWAP, or refuses.
+
+Before this contract existed the enum resolved to the close, and under
+``NEXT_BAR`` the ``use_open`` short-circuit returned before the VWAP branch was
+consulted at all - so a VWAP fill returned the *open*. Both substitutions were
+silent, and no test in the suite could tell the three prices apart. Every case
+here therefore uses an open, a close and a VWAP that are mutually distinct: a
+fixture where any two coincide cannot fail against the old behaviour.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import polars as pl
+import pytest
+
+from ml4t.backtest import Broker
+from ml4t.backtest.config import ExecutionMode, ExecutionPrice
+from ml4t.backtest.datafeed import DataFeed
+from ml4t.backtest.models import NoCommission, NoSlippage
+from ml4t.backtest.types import OrderSide
+
+OPEN = 99.0
+CLOSE = 102.0
+VWAP = 100.5  # deliberately between the two, and equal to neither
+
+
+def _broker(mode: ExecutionMode = ExecutionMode.SAME_BAR) -> Broker:
+    return Broker(
+        initial_cash=100_000.0,
+        commission_model=NoCommission(),
+        slippage_model=NoSlippage(),
+        execution_price=ExecutionPrice.VWAP,
+        execution_mode=mode,
+    )
+
+
+def _advance(broker: Broker, *, vwaps: dict[str, float] | None = None) -> None:
+    broker._update_time(
+        timestamp=datetime(2024, 1, 2, 9, 31),
+        prices={"AAPL": CLOSE},
+        opens={"AAPL": OPEN},
+        highs={"AAPL": 105.0},
+        lows={"AAPL": 95.0},
+        closes={"AAPL": CLOSE},
+        volumes={"AAPL": 1_000_000.0},
+        vwaps={"AAPL": VWAP} if vwaps is None else vwaps,
+        signals={},
+    )
+
+
+class TestVwapIsItsOwnPrice:
+    def test_same_bar_fill_takes_the_vwap_not_the_close(self):
+        broker = _broker()
+        _advance(broker)
+        assert broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL") == VWAP
+
+    def test_next_bar_fill_takes_the_vwap_not_the_open(self):
+        # The regression that motivated this file: use_open short-circuited ahead of
+        # the VWAP branch, so this returned OPEN however the branch was written.
+        broker = _broker(ExecutionMode.NEXT_BAR)
+        _advance(broker)
+        price = broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL", use_open=True)
+        assert price == VWAP
+        assert price != OPEN
+
+    def test_a_quote_source_still_ignores_the_vwap(self):
+        broker = _broker(ExecutionMode.NEXT_BAR)
+        _advance(broker)
+        assert broker.get_price_for_source(ExecutionPrice.OPEN, "AAPL", use_open=True) == OPEN
+        assert broker.get_price_for_source(ExecutionPrice.CLOSE, "AAPL") == CLOSE
+
+    def test_an_executed_order_books_at_the_vwap(self):
+        broker = _broker()
+        _advance(broker)
+        broker.submit_order("AAPL", 10.0, OrderSide.BUY)
+        broker._process_orders()
+        position = broker.get_position("AAPL")
+        assert position is not None
+        assert position.entry_price == VWAP
+
+
+class TestARefusalRatherThanASubstitution:
+    def test_a_feed_without_a_vwap_raises(self):
+        broker = _broker()
+        _advance(broker, vwaps={})
+        with pytest.raises(ValueError, match="carries no VWAP"):
+            broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL")
+
+    def test_the_refusal_names_the_field_that_fixes_it(self):
+        broker = _broker()
+        _advance(broker, vwaps={})
+        with pytest.raises(ValueError, match="vwap_col"):
+            broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL")
+
+    def test_one_asset_missing_a_vwap_does_not_silence_another(self):
+        broker = _broker()
+        _advance(broker, vwaps={"MSFT": VWAP})
+        with pytest.raises(ValueError, match="'AAPL'"):
+            broker.get_price_for_source(ExecutionPrice.VWAP, "AAPL")
+
+
+class TestTheFeedCarriesItThrough:
+    def test_a_declared_vwap_col_reaches_the_bar(self):
+        prices = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 2, 9, 31)],
+                "symbol": ["AAPL"],
+                "open": [OPEN],
+                "high": [105.0],
+                "low": [95.0],
+                "close": [CLOSE],
+                "volume": [1_000_000.0],
+                "vwap": [VWAP],
+            }
+        )
+        feed = DataFeed(prices_df=prices, entity_col="symbol", vwap_col="vwap")
+        _timestamp, assets, _context = next(iter(feed))
+        assert assets["AAPL"]["vwap"] == VWAP
+        assert assets._vwaps["AAPL"] == VWAP
+
+    def test_an_undeclared_vwap_column_is_not_guessed_at(self):
+        # The column is present and named exactly "vwap", but the feed does not declare
+        # it. Picking it up anyway would make the contract depend on a naming
+        # convention rather than on the spec.
+        prices = pl.DataFrame(
+            {
+                "timestamp": [datetime(2024, 1, 2, 9, 31)],
+                "symbol": ["AAPL"],
+                "open": [OPEN],
+                "high": [105.0],
+                "low": [95.0],
+                "close": [CLOSE],
+                "volume": [1_000_000.0],
+                "vwap": [VWAP],
+            }
+        )
+        feed = DataFeed(prices_df=prices, entity_col="symbol")
+        _timestamp, assets, _context = next(iter(feed))
+        assert "vwap" not in assets["AAPL"]
+        assert assets._vwaps == {}

--- a/uv.lock
+++ b/uv.lock
@@ -1902,7 +1902,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
     { name = "ml4t-diagnostic", marker = "extra == 'all'", specifier = ">=0.1.0b4" },
     { name = "ml4t-diagnostic", marker = "extra == 'dev'", specifier = ">=0.1.0b4" },
-    { name = "ml4t-specs", specifier = ">=0.1.2,<0.2" },
+    { name = "ml4t-specs", git = "https://github.com/ml4t/specs.git?branch=feat%2Ffeedspec-vwap-col" },
     { name = "networkx", marker = "extra == 'advanced'", specifier = ">=3.0" },
     { name = "networkx", marker = "extra == 'all'", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=2.3.2" },
@@ -2083,14 +2083,10 @@ wheels = [
 
 [[package]]
 name = "ml4t-specs"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.3"
+source = { git = "https://github.com/ml4t/specs.git?branch=feat%2Ffeedspec-vwap-col#1b1f432eece5c3e85b978caf4f4657cadaaa3059" }
 dependencies = [
     { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6b/58aacbc7ccf9239edb5f3b350b418aff543f87698852e1507892c2ce8c26/ml4t_specs-0.1.2.tar.gz", hash = "sha256:72131624220bdded7d01d9c09e4c9e6637e8e977a37be283bc7f38d4fe0b1e1a", size = 50590, upload-time = "2026-08-10T00:53:01.695Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/97/1508cd131272885391fe17eb54865d8c2ee0a853d15bdd5cfd838b20ce44/ml4t_specs-0.1.2-py3-none-any.whl", hash = "sha256:c9e6749bc28c087f1a97494690edae94460aeffe2c223494a19c41c4915b9532", size = 33763, upload-time = "2026-08-10T00:53:00.474Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1902,7 +1902,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
     { name = "ml4t-diagnostic", marker = "extra == 'all'", specifier = ">=0.1.0b4" },
     { name = "ml4t-diagnostic", marker = "extra == 'dev'", specifier = ">=0.1.0b4" },
-    { name = "ml4t-specs", git = "https://github.com/ml4t/specs.git?branch=feat%2Ffeedspec-vwap-col" },
+    { name = "ml4t-specs", specifier = ">=0.1.4,<0.2" },
     { name = "networkx", marker = "extra == 'advanced'", specifier = ">=3.0" },
     { name = "networkx", marker = "extra == 'all'", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=2.3.2" },
@@ -2083,10 +2083,14 @@ wheels = [
 
 [[package]]
 name = "ml4t-specs"
-version = "0.1.3"
-source = { git = "https://github.com/ml4t/specs.git?branch=feat%2Ffeedspec-vwap-col#1b1f432eece5c3e85b978caf4f4657cadaaa3059" }
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/52/ba5c172ef1eddd3727832123dd6abf380ff39d36083ec37864bc488c2bd7/ml4t_specs-0.1.4.tar.gz", hash = "sha256:bc8e417e8049a05847ca30de52a59e28a18539c5e8aef8711dc5d57d7752e0a4", size = 51355, upload-time = "2026-09-03T02:06:36.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/1f/d03958fb90ac08adc78465e915501b1043ff7d12b68485592dac6139e59a/ml4t_specs-0.1.4-py3-none-any.whl", hash = "sha256:459928f55edb0c62dde535fc391f38446774bca821c5774617d40b50a0289725", size = 34033, upload-time = "2026-09-03T02:06:35.49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`ExecutionPrice.VWAP` has been declared since the enum was written and has never read a VWAP.

```python
# broker.py, before
if source == ExecutionPrice.VWAP:
    return self._current_prices.get(asset, self._current_closes.get(asset))
```

That is character-for-character what `ExecutionPrice.PRICE` returns four lines above it, and there was no `vwap_col` anywhere in the feed contract for it to read even if it had wanted one.

## Why fixing the lookup alone would have been worse than leaving it

The branch is **unreachable under `next_bar`**. The `use_open` short-circuit excludes only `BID`, `ASK`, `QUOTE_MID` and `QUOTE_SIDE`, so a VWAP request returned the next bar's **open** whatever the VWAP branch said. Landing a real lookup without also removing VWAP from that set would have left the behaviour exactly as it is while making the enum, the config, the data and the new store all read correctly to a reviewer. Both halves are here.

## What changed

| | |
|---|---|
| `FeedSpec.vwap_col` | declares the column (ml4t/specs#13) |
| `DataFeed` | carries it into `_AssetsData._vwaps` and `MarketState.vwaps`, beside the existing OHLCV caches |
| `use_open` exclusion set | gains `ExecutionPrice.VWAP` - a VWAP is already a whole-bar price and the open must not override it |
| `Engine.__init__` | rejects `execution_price=VWAP` against a feed declaring no `vwap_col`, once, before the first bar |
| a bar with no VWAP | resolves to `None`, so the order goes unfilled |
| `_update_time` | keeps its 2- and 8-positional forms; gains a 9-positional and a `vwaps=` keyword form |

## The two cases are different, and separating them is the point

Neither falls back to the close. On a no-trade bar the close is a **stale carried print**, so substituting it invents a fill at a price nothing transacted at - the original defect, in a new place.

But they fail differently:

- **No `vwap_col` declared at all** is a configuration error. It cannot be right for any bar, so it is caught once at `Engine` construction rather than discovered at the first fill.
- **An individual asset-bar with no VWAP** is an ordinary market state: nothing traded, so there is no volume-weighted price. `get_price_for_source` returns `None`, and every caller in `execution_engine.py` already guards with `if price is None: continue`. The order does not fill and the prior position stands - which is what happens to a real order resting in a bar with no prints, and it needs no new machinery.

An earlier revision of this PR raised in both cases. The `nasdaq100_microstructure` lane asked whether the raise fires upstream of that `continue`, and it does: the fill path is `FillEngine.get_fill_price_for_order` → `broker.get_price_for_source(broker.execution_price, ...)`. Raising there turned an ordinary no-trade bar into a stopped run.

**The rate is why this matters.** On the NASDAQ-100 production universe (102 symbols, March 2021), **0.2384%** of symbol-minutes inside 09:30-16:00 carry no print - worst name CTAS at 2.95%. Across all hours it is 5.02%, but that population is pre- and post-market and the case study trades the exchange session. A raise would have stopped a run reliably; a fallback would have silently mispriced one bar in 420.

## Verification

`1970 passed, 14 skipped`.

`tests/test_vwap_execution_price.py` sets an open of 99.0, a close of 102.0 and a VWAP of 100.5 - mutually distinct, because a fixture where any two coincide cannot fail against the old behaviour. **6 of the original 9 cases fail against the previous broker and pass against this one**; I checked that by reverting the two behavioural changes and re-running, not by assuming it.

The compatibility snapshot is regenerated. Both surface changes are additive - a nullable field and a keyword-only parameter with a default - so no existing caller breaks. `_current_vwaps` is registered in `test_broker_state_ownership`'s explicit-decision list, where the gate correctly demanded it.

## Dependency (resolved)

`FeedSpec.vwap_col` shipped in **ml4t-specs 0.1.4** (ml4t/specs#13, merged as `b17105b`). The temporary `[tool.uv.sources]` git pin is deleted in `552ee4f` and the floor raised to `ml4t-specs>=0.1.4,<0.2`. That pin was also the sole cause of the red Compatibility jobs: they run `--locked`, which a git-sourced dependency cannot satisfy. Nothing is outstanding before merge.

## Blast radius

**No published number moves.** No case study configures `execution_price: vwap` today - the eight active presets use `quote_side`, `close` or `open` - so nothing has ever been filled at a substituted price. This is an API-surface defect caught before its first use.

The first use is `nasdaq100_microstructure`, being rebuilt on a fixed 15-minute decision clock over one-minute bars where the settled execution assumption is the next minute's VWAP (ml4t/agent-workspace#187). Without this change that case study would have filled at the open - the assumption the design explicitly rejected for implying near-zero execution latency - and the run would have looked correct.

Closes ml4t/agent-workspace#1017.

