### PR TITLE
docs: publish real-strategy performance evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,31 @@ The parity protocol disables transaction costs and position rules on both sides.
 | US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000190); terminal within $0.01 (raw gap $0.00000030) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 | US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000460); terminal within $0.01 (raw gap $0.00000420) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 
-Engine-only timing samples for all 17 passing pairs are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json). These measurements support only the named strategy, framework version, input bundle, and machine.
+### Real-strategy engine performance
+
+The table reports engine-call wall time for all 17 correctness-passing pairs. The ratio is framework median / ML4T median; values above 1 mean ML4T completed the engine call faster.
+
+| Real strategy | Pinned framework | Framework median (95% CI), s | ML4T median (95% CI), s | Framework / ML4T median |
+|---|---|---:|---:|---:|
+| ETF allocation | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.287 (0.286-0.289) | 0.415 (0.414-0.419) | 0.692x |
+| ETF allocation | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.171 (0.171-0.174) | 0.415 (0.413-0.417) | 0.412x |
+| ETF allocation | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 9.355 (9.303-9.424) | 0.430 (0.426-0.432) | 21.762x |
+| ETF allocation | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 3.872 (3.867-3.910) | 0.632 (0.628-0.638) | 6.127x |
+| ETF allocation | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.564 (2.487-2.599) | 0.750 (0.749-0.757) | 3.418x |
+| CME futures | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.286 (0.284-0.289) | 0.432 (0.429-0.435) | 0.663x |
+| CME futures | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 2.495 (2.488-2.526) | 0.429 (0.427-0.433) | 5.812x |
+| Crypto perpetual funding | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.801 (2.709-2.891) | 0.657 (0.655-0.661) | 4.266x |
+| FX allocation (USD-quoted pairs) | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.283 (0.281-0.286) | 0.146 (0.145-0.147) | 1.939x |
+| FX allocation (USD-quoted pairs) | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.139 (0.138-0.141) | 0.146 (0.145-0.147) | 0.952x |
+| FX allocation (USD-quoted pairs) | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 0.425 (0.420-0.432) | 0.146 (0.145-0.147) | 2.920x |
+| FX allocation (USD-quoted pairs) | [LEAN 18001](https://github.com/QuantConnect/Lean) | 0.913 (0.877-0.953) | 0.153 (0.152-0.157) | 5.952x |
+| US equity panel | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.795 (0.787-0.838) | 20.555 (20.486-20.600) | 0.039x |
+| US equity panel | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 16.995 (16.960-17.024) | 20.495 (20.453-20.534) | 0.829x |
+| US equity panel | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 495.553 (494.227-510.273) | 21.470 (21.386-21.543) | 23.082x |
+| US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 107.609 (106.834-109.150) | 22.132 (22.082-22.234) | 4.862x |
+| US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | 47.683 (47.333-48.015) | 26.368 (26.222-26.473) | 1.808x |
+
+Measured 2026-09-03 on `Linux-6.8.0-138-generic-x86_64-with-glibc2.39` with 24 logical CPUs. Each side used one isolated warm-up process and ten isolated measured processes. The timer includes only the engine call; it excludes input loading, model inference, target construction, adapter preparation, result extraction, serialization, reporting. These measurements apply only to the named strategy, framework version, frozen input bundle, and machine. Raw samples and bootstrap intervals are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json).
 
 ### Synthetic diagnostic scenarios
 
@@ -368,19 +392,21 @@ uv run pytest tests/benchmark/test_hotpath_benchmarks.py::test_optimized_feed_ru
 ```
 
 Workload definitions and expected checksums are retained in
-`validation/performance_baselines.json`. The project does not publish hardware-dependent runtime,
-throughput, memory, or cross-framework ratios as stable claims.
+`validation/performance_baselines.json`. These ML4T-only measurements are regression baselines,
+not cross-machine performance claims.
 
 Cross-framework performance evidence uses a common 50-asset, 252-session controlled workload.
 Each runner receives one isolated warm-up followed by ten isolated measurements. The retained
 artifact contains raw samples, whole-process wall time, process-tree peak RSS, deterministic 95%
 bootstrap intervals, output checksums, framework identities, and semantic disclosures for the
-idiomatic view. The results remain audit evidence pending a separate publication decision.
+idiomatic view. This controlled synthetic workload remains supporting audit evidence rather than
+the basis for the published real-strategy comparison above.
 
 The real-strategy performance artifact times only engine execution for correctness-passing pairs.
 Inputs, model inference, target construction, adapter preparation, extraction, and reporting are
-excluded. See `validation/REAL_STRATEGY_PERFORMANCE.json`; its ratios are dated audit measurements,
-not stable framework claims.
+excluded. The table above publishes the measured ratios with their date, versions, workload, host,
+and uncertainty. They describe those executions and do not establish a hardware-independent speed
+ranking.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,7 +130,31 @@ The parity protocol disables transaction costs and position rules on both sides.
 | US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000190); terminal within $0.01 (raw gap $0.00000030) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 | US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000460); terminal within $0.01 (raw gap $0.00000420) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 
-Engine-only timing samples for all 17 passing pairs are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json). These measurements support only the named strategy, framework version, input bundle, and machine.
+### Real-strategy engine performance
+
+The table reports engine-call wall time for all 17 correctness-passing pairs. The ratio is framework median / ML4T median; values above 1 mean ML4T completed the engine call faster.
+
+| Real strategy | Pinned framework | Framework median (95% CI), s | ML4T median (95% CI), s | Framework / ML4T median |
+|---|---|---:|---:|---:|
+| ETF allocation | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.287 (0.286-0.289) | 0.415 (0.414-0.419) | 0.692x |
+| ETF allocation | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.171 (0.171-0.174) | 0.415 (0.413-0.417) | 0.412x |
+| ETF allocation | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 9.355 (9.303-9.424) | 0.430 (0.426-0.432) | 21.762x |
+| ETF allocation | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 3.872 (3.867-3.910) | 0.632 (0.628-0.638) | 6.127x |
+| ETF allocation | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.564 (2.487-2.599) | 0.750 (0.749-0.757) | 3.418x |
+| CME futures | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.286 (0.284-0.289) | 0.432 (0.429-0.435) | 0.663x |
+| CME futures | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 2.495 (2.488-2.526) | 0.429 (0.427-0.433) | 5.812x |
+| Crypto perpetual funding | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.801 (2.709-2.891) | 0.657 (0.655-0.661) | 4.266x |
+| FX allocation (USD-quoted pairs) | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.283 (0.281-0.286) | 0.146 (0.145-0.147) | 1.939x |
+| FX allocation (USD-quoted pairs) | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.139 (0.138-0.141) | 0.146 (0.145-0.147) | 0.952x |
+| FX allocation (USD-quoted pairs) | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 0.425 (0.420-0.432) | 0.146 (0.145-0.147) | 2.920x |
+| FX allocation (USD-quoted pairs) | [LEAN 18001](https://github.com/QuantConnect/Lean) | 0.913 (0.877-0.953) | 0.153 (0.152-0.157) | 5.952x |
+| US equity panel | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.795 (0.787-0.838) | 20.555 (20.486-20.600) | 0.039x |
+| US equity panel | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 16.995 (16.960-17.024) | 20.495 (20.453-20.534) | 0.829x |
+| US equity panel | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 495.553 (494.227-510.273) | 21.470 (21.386-21.543) | 23.082x |
+| US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 107.609 (106.834-109.150) | 22.132 (22.082-22.234) | 4.862x |
+| US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | 47.683 (47.333-48.015) | 26.368 (26.222-26.473) | 1.808x |
+
+Measured 2026-09-03 on `Linux-6.8.0-138-generic-x86_64-with-glibc2.39` with 24 logical CPUs. Each side used one isolated warm-up process and ten isolated measured processes. The timer includes only the engine call; it excludes input loading, model inference, target construction, adapter preparation, result extraction, serialization, reporting. These measurements apply only to the named strategy, framework version, frozen input bundle, and machine. Raw samples and bootstrap intervals are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json).
 
 ### Synthetic diagnostic scenarios
 
@@ -159,13 +183,15 @@ rebalance, and partial-fill workloads in isolated processes. It reports setup an
 separately, measures whole-process peak RSS, and verifies retained financial-output checksums and
 counts. The 250-asset workload periodically enters and exits 50 positions. Sample spread is
 reported for diagnosis, while the
-instrument-free hotpath benchmark enforces the runtime regression limit. The project does not
-publish hardware-dependent performance ratios as stable claims.
+instrument-free hotpath benchmark enforces the runtime regression limit. These ML4T-only
+measurements are regression baselines, not cross-machine performance claims.
 
 The separate cross-framework performance artifact retains ten isolated measurements per runner
 after one warm-up. It reports complete-process wall time, process-tree and LEAN-container peak RSS,
 raw samples, 95% bootstrap intervals, exact output checksums, and semantic disclosures. It is
-retained as audit evidence without stable speed or memory ratios pending a publication decision.
+retained as supporting audit evidence. The published table above instead reports engine-only
+timings for the realistic, correctness-passing workloads and states the workload, versions, host,
+date, and uncertainty needed to interpret each ratio.
 
 ## Installation
 

--- a/docs/user-guide/profiles.md
+++ b/docs/user-guide/profiles.md
@@ -188,7 +188,31 @@ The parity protocol disables transaction costs and position rules on both sides.
 | US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000190); terminal within $0.01 (raw gap $0.00000030) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 | US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000460); terminal within $0.01 (raw gap $0.00000420) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 
-Engine-only timing samples for all 17 passing pairs are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json). These measurements support only the named strategy, framework version, input bundle, and machine.
+### Real-strategy engine performance
+
+The table reports engine-call wall time for all 17 correctness-passing pairs. The ratio is framework median / ML4T median; values above 1 mean ML4T completed the engine call faster.
+
+| Real strategy | Pinned framework | Framework median (95% CI), s | ML4T median (95% CI), s | Framework / ML4T median |
+|---|---|---:|---:|---:|
+| ETF allocation | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.287 (0.286-0.289) | 0.415 (0.414-0.419) | 0.692x |
+| ETF allocation | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.171 (0.171-0.174) | 0.415 (0.413-0.417) | 0.412x |
+| ETF allocation | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 9.355 (9.303-9.424) | 0.430 (0.426-0.432) | 21.762x |
+| ETF allocation | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 3.872 (3.867-3.910) | 0.632 (0.628-0.638) | 6.127x |
+| ETF allocation | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.564 (2.487-2.599) | 0.750 (0.749-0.757) | 3.418x |
+| CME futures | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.286 (0.284-0.289) | 0.432 (0.429-0.435) | 0.663x |
+| CME futures | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 2.495 (2.488-2.526) | 0.429 (0.427-0.433) | 5.812x |
+| Crypto perpetual funding | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.801 (2.709-2.891) | 0.657 (0.655-0.661) | 4.266x |
+| FX allocation (USD-quoted pairs) | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.283 (0.281-0.286) | 0.146 (0.145-0.147) | 1.939x |
+| FX allocation (USD-quoted pairs) | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.139 (0.138-0.141) | 0.146 (0.145-0.147) | 0.952x |
+| FX allocation (USD-quoted pairs) | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 0.425 (0.420-0.432) | 0.146 (0.145-0.147) | 2.920x |
+| FX allocation (USD-quoted pairs) | [LEAN 18001](https://github.com/QuantConnect/Lean) | 0.913 (0.877-0.953) | 0.153 (0.152-0.157) | 5.952x |
+| US equity panel | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.795 (0.787-0.838) | 20.555 (20.486-20.600) | 0.039x |
+| US equity panel | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 16.995 (16.960-17.024) | 20.495 (20.453-20.534) | 0.829x |
+| US equity panel | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 495.553 (494.227-510.273) | 21.470 (21.386-21.543) | 23.082x |
+| US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 107.609 (106.834-109.150) | 22.132 (22.082-22.234) | 4.862x |
+| US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | 47.683 (47.333-48.015) | 26.368 (26.222-26.473) | 1.808x |
+
+Measured 2026-09-03 on `Linux-6.8.0-138-generic-x86_64-with-glibc2.39` with 24 logical CPUs. Each side used one isolated warm-up process and ten isolated measured processes. The timer includes only the engine call; it excludes input loading, model inference, target construction, adapter preparation, result extraction, serialization, reporting. These measurements apply only to the named strategy, framework version, frozen input bundle, and machine. Raw samples and bootstrap intervals are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json).
 
 ### Synthetic diagnostic scenarios
 
@@ -214,16 +238,15 @@ The synthetic stress workload contains 250 assets and 5,040 daily sessions (1,26
 
 ## Performance
 
-The stable release does not publish cross-framework speed ratios. ML4T-only regression evidence is
-defined in `validation/performance_baselines.json`. The separate retained cross-framework artifact
-uses one warm-up and ten process-isolated measurements per runner, with raw samples, median and 95%
-intervals, process-tree peak RSS, exact output checksums, and an idiomatic view that makes no
-equivalence claim.
+ML4T-only regression evidence is defined in `validation/performance_baselines.json`. The separate
+controlled cross-framework artifact uses one warm-up and ten process-isolated measurements per
+runner, with raw samples, median and 95% intervals, process-tree peak RSS, exact output checksums,
+and an idiomatic view that makes no equivalence claim.
 
-`validation/REAL_STRATEGY_PERFORMANCE.json` separately retains engine-only timings for the six
-real-strategy pairs that passed correctness. It excludes data loading, inference, target
-construction, adapter preparation, extraction, and reporting. The results apply only to the named
-versions, bundles, and machine.
+The table above publishes engine-only timings for all 17 real-strategy pairs that passed
+correctness. It excludes data loading, inference, target construction, adapter preparation,
+extraction, and reporting. The ratios apply only to the named versions, frozen input bundles,
+measurement date, and machine.
 
 ## Listing Profiles
 

--- a/tests/contracts/test_framework_target_manifest.py
+++ b/tests/contracts/test_framework_target_manifest.py
@@ -162,8 +162,10 @@ def test_claim_inventory_accounts_for_all_repositories_and_known_targets() -> No
         "performance",
         "qualitative",
     }
-    assert inventory.unresolved
-    assert all(item.issue.startswith("ml4t/backtest-dev#") for item in inventory.unresolved)
+    assert inventory.unresolved == ()
+    statuses = {claim.claim_id: claim.status for claim in inventory.claims}
+    assert statuses["library-real-strategy-equivalence"] == "verified"
+    assert statuses["library-real-strategy-performance"] == "verified"
     local_paths = {
         path
         for claim in inventory.claims

--- a/tests/contracts/test_parity_claim_generation.py
+++ b/tests/contracts/test_parity_claim_generation.py
@@ -84,6 +84,43 @@ def test_every_claim_target_uses_the_same_generated_block() -> None:
     assert len(set(blocks)) == 1
 
 
+def test_claims_publish_real_strategy_engine_timings_with_provenance() -> None:
+    correctness = generate_parity_claims._load_json(generate_parity_claims.CORRECTNESS_EVIDENCE)
+    large_scale = generate_parity_claims._load_json(generate_parity_claims.LARGE_SCALE_EVIDENCE)
+    real_strategy = generate_parity_claims._load_json(generate_parity_claims.REAL_STRATEGY_EVIDENCE)
+    performance = generate_parity_claims._load_json(
+        generate_parity_claims.REAL_STRATEGY_PERFORMANCE
+    )
+
+    claims = generate_parity_claims.render_claims(
+        correctness, large_scale, real_strategy, performance
+    )
+
+    assert "### Real-strategy engine performance" in claims
+    assert "Framework / ML4T median" in claims
+    for record in performance["records"]:
+        framework_result = record["framework_engine"]
+        ml4t_result = record["ml4t_engine"]
+        framework_ci = framework_result["ci_95_seconds"]
+        ml4t_ci = ml4t_result["ci_95_seconds"]
+        expected_measurements = (
+            f"{framework_result['median_seconds']:.3f} "
+            f"({framework_ci[0]:.3f}-{framework_ci[1]:.3f}) | "
+            f"{ml4t_result['median_seconds']:.3f} "
+            f"({ml4t_ci[0]:.3f}-{ml4t_ci[1]:.3f}) | "
+            f"{record['framework_to_ml4t_median_ratio']:.3f}x"
+        )
+        assert expected_measurements in claims
+
+    assert performance["generated_at"][:10] in claims
+    assert performance["environment"]["platform"] in claims
+    assert f"{performance['environment']['cpu_count']} logical CPUs" in claims
+    assert "one isolated warm-up process and ten isolated measured processes" in claims
+    assert "values above 1 mean ML4T completed the engine call faster" in claims
+    for excluded in performance["timing_policy"]["excluded"]:
+        assert excluded in claims
+
+
 def test_claims_pin_every_advertised_framework_and_expose_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/validation/METHODOLOGY.md
+++ b/validation/METHODOLOGY.md
@@ -374,7 +374,31 @@ The parity protocol disables transaction costs and position rules on both sides.
 | US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000190); terminal within $0.01 (raw gap $0.00000030) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 | US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000460); terminal within $0.01 (raw gap $0.00000420) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 
-Engine-only timing samples for all 17 passing pairs are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json). These measurements support only the named strategy, framework version, input bundle, and machine.
+### Real-strategy engine performance
+
+The table reports engine-call wall time for all 17 correctness-passing pairs. The ratio is framework median / ML4T median; values above 1 mean ML4T completed the engine call faster.
+
+| Real strategy | Pinned framework | Framework median (95% CI), s | ML4T median (95% CI), s | Framework / ML4T median |
+|---|---|---:|---:|---:|
+| ETF allocation | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.287 (0.286-0.289) | 0.415 (0.414-0.419) | 0.692x |
+| ETF allocation | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.171 (0.171-0.174) | 0.415 (0.413-0.417) | 0.412x |
+| ETF allocation | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 9.355 (9.303-9.424) | 0.430 (0.426-0.432) | 21.762x |
+| ETF allocation | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 3.872 (3.867-3.910) | 0.632 (0.628-0.638) | 6.127x |
+| ETF allocation | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.564 (2.487-2.599) | 0.750 (0.749-0.757) | 3.418x |
+| CME futures | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.286 (0.284-0.289) | 0.432 (0.429-0.435) | 0.663x |
+| CME futures | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 2.495 (2.488-2.526) | 0.429 (0.427-0.433) | 5.812x |
+| Crypto perpetual funding | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.801 (2.709-2.891) | 0.657 (0.655-0.661) | 4.266x |
+| FX allocation (USD-quoted pairs) | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.283 (0.281-0.286) | 0.146 (0.145-0.147) | 1.939x |
+| FX allocation (USD-quoted pairs) | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.139 (0.138-0.141) | 0.146 (0.145-0.147) | 0.952x |
+| FX allocation (USD-quoted pairs) | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 0.425 (0.420-0.432) | 0.146 (0.145-0.147) | 2.920x |
+| FX allocation (USD-quoted pairs) | [LEAN 18001](https://github.com/QuantConnect/Lean) | 0.913 (0.877-0.953) | 0.153 (0.152-0.157) | 5.952x |
+| US equity panel | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.795 (0.787-0.838) | 20.555 (20.486-20.600) | 0.039x |
+| US equity panel | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 16.995 (16.960-17.024) | 20.495 (20.453-20.534) | 0.829x |
+| US equity panel | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 495.553 (494.227-510.273) | 21.470 (21.386-21.543) | 23.082x |
+| US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 107.609 (106.834-109.150) | 22.132 (22.082-22.234) | 4.862x |
+| US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | 47.683 (47.333-48.015) | 26.368 (26.222-26.473) | 1.808x |
+
+Measured 2026-09-03 on `Linux-6.8.0-138-generic-x86_64-with-glibc2.39` with 24 logical CPUs. Each side used one isolated warm-up process and ten isolated measured processes. The timer includes only the engine call; it excludes input loading, model inference, target construction, adapter preparation, result extraction, serialization, reporting. These measurements apply only to the named strategy, framework version, frozen input bundle, and machine. Raw samples and bootstrap intervals are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json).
 
 ### Synthetic diagnostic scenarios
 

--- a/validation/README.md
+++ b/validation/README.md
@@ -50,7 +50,31 @@ The parity protocol disables transaction costs and position rules on both sides.
 | US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000190); terminal within $0.01 (raw gap $0.00000030) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 | US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | fills equal at declared field precision; 4,027 valuations within $0.01 (max raw gap $0.00000460); terminal within $0.01 (raw gap $0.00000420) | [real-strategy evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_RESULTS.json) |
 
-Engine-only timing samples for all 17 passing pairs are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json). These measurements support only the named strategy, framework version, input bundle, and machine.
+### Real-strategy engine performance
+
+The table reports engine-call wall time for all 17 correctness-passing pairs. The ratio is framework median / ML4T median; values above 1 mean ML4T completed the engine call faster.
+
+| Real strategy | Pinned framework | Framework median (95% CI), s | ML4T median (95% CI), s | Framework / ML4T median |
+|---|---|---:|---:|---:|
+| ETF allocation | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.287 (0.286-0.289) | 0.415 (0.414-0.419) | 0.692x |
+| ETF allocation | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.171 (0.171-0.174) | 0.415 (0.413-0.417) | 0.412x |
+| ETF allocation | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 9.355 (9.303-9.424) | 0.430 (0.426-0.432) | 21.762x |
+| ETF allocation | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 3.872 (3.867-3.910) | 0.632 (0.628-0.638) | 6.127x |
+| ETF allocation | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.564 (2.487-2.599) | 0.750 (0.749-0.757) | 3.418x |
+| CME futures | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.286 (0.284-0.289) | 0.432 (0.429-0.435) | 0.663x |
+| CME futures | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 2.495 (2.488-2.526) | 0.429 (0.427-0.433) | 5.812x |
+| Crypto perpetual funding | [LEAN 18001](https://github.com/QuantConnect/Lean) | 2.801 (2.709-2.891) | 0.657 (0.655-0.661) | 4.266x |
+| FX allocation (USD-quoted pairs) | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.283 (0.281-0.286) | 0.146 (0.145-0.147) | 1.939x |
+| FX allocation (USD-quoted pairs) | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 0.139 (0.138-0.141) | 0.146 (0.145-0.147) | 0.952x |
+| FX allocation (USD-quoted pairs) | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 0.425 (0.420-0.432) | 0.146 (0.145-0.147) | 2.920x |
+| FX allocation (USD-quoted pairs) | [LEAN 18001](https://github.com/QuantConnect/Lean) | 0.913 (0.877-0.953) | 0.153 (0.152-0.157) | 5.952x |
+| US equity panel | [VectorBT Pro 2026.6.27](https://github.com/polakowo/vectorbt.pro) | 0.795 (0.787-0.838) | 20.555 (20.486-20.600) | 0.039x |
+| US equity panel | [VectorBT OSS 1.1.0](https://pypi.org/project/vectorbt/1.1.0/) | 16.995 (16.960-17.024) | 20.495 (20.453-20.534) | 0.829x |
+| US equity panel | [Backtrader 1.9.78.123](https://pypi.org/project/backtrader/1.9.78.123/) | 495.553 (494.227-510.273) | 21.470 (21.386-21.543) | 23.082x |
+| US equity panel | [Zipline Reloaded 3.1.1](https://pypi.org/project/zipline-reloaded/3.1.1/) | 107.609 (106.834-109.150) | 22.132 (22.082-22.234) | 4.862x |
+| US equity panel | [LEAN 18001](https://github.com/QuantConnect/Lean) | 47.683 (47.333-48.015) | 26.368 (26.222-26.473) | 1.808x |
+
+Measured 2026-09-03 on `Linux-6.8.0-138-generic-x86_64-with-glibc2.39` with 24 logical CPUs. Each side used one isolated warm-up process and ten isolated measured processes. The timer includes only the engine call; it excludes input loading, model inference, target construction, adapter preparation, result extraction, serialization, reporting. These measurements apply only to the named strategy, framework version, frozen input bundle, and machine. Raw samples and bootstrap intervals are retained in [real-strategy performance evidence](https://github.com/ml4t/backtest/blob/main/validation/REAL_STRATEGY_PERFORMANCE.json).
 
 ### Synthetic diagnostic scenarios
 
@@ -154,7 +178,8 @@ uv run python validation/cross_framework_performance.py --samples 10
 The performance runner uses one isolated warm-up and ten isolated measurements per runner. It
 retains complete-process wall time, process-tree peak RSS including the LEAN container, raw
 samples, deterministic 95% bootstrap intervals, exact output checksums, immutable framework
-identities, and semantic disclosures for an idiomatic view. No stable ratio claim is generated.
+identities, and semantic disclosures for an idiomatic view. This controlled synthetic artifact is
+not used for the published real-strategy ratios above.
 
 ## Virtual Environment Setup
 

--- a/validation/claim_inventory.toml
+++ b/validation/claim_inventory.toml
@@ -1,3 +1,5 @@
+unresolved = []
+
 [metadata]
 schema_version = 1
 audit_date = "2026-08-13"
@@ -19,7 +21,7 @@ paths = ["README.md", "docs/index.md", "docs/user-guide/profiles.md", "validatio
 type = "correctness"
 frameworks = ["vectorbt_pro", "vectorbt_oss", "backtrader", "zipline", "lean"]
 required_evidence = ["frozen_real_strategy_inputs", "complete_canonical_fill_log", "equity_curve", "terminal_value", "negative_control", "environment_identity"]
-status = "failed"
+status = "verified"
 issue = "ml4t/backtest-dev#3"
 
 [[claim]]
@@ -85,7 +87,7 @@ issue = "ml4t/backtest-dev#11"
 [[claim]]
 id = "library-real-strategy-performance"
 repository = "ml4t/backtest"
-paths = ["validation/real_strategy_benchmark.py", "validation/REAL_STRATEGY_PERFORMANCE.json", "validation/REAL_STRATEGY_RESULTS.json"]
+paths = ["README.md", "docs/index.md", "docs/user-guide/profiles.md", "validation/README.md", "validation/METHODOLOGY.md", "validation/real_strategy_benchmark.py", "validation/REAL_STRATEGY_PERFORMANCE.json", "validation/REAL_STRATEGY_RESULTS.json"]
 type = "performance"
 frameworks = ["vectorbt_pro", "vectorbt_oss", "backtrader", "zipline", "lean"]
 required_evidence = ["correctness_passing_workload", "engine_only_timer", "warmup_policy", "repetitions", "machine_identity", "raw_timings", "output_identity"]
@@ -170,9 +172,4 @@ type = "qualitative"
 frameworks = ["vectorbt_pro", "vectorbt_oss", "backtrader", "zipline", "lean"]
 required_evidence = ["published_library_evidence", "upstream_source_reference", "scope_qualification"]
 status = "unresolved"
-issue = "ml4t/backtest-dev#15"
-
-[[unresolved]]
-id = "performance-publication-decision"
-finding = "Whether to publish dated cross-framework runtime or memory ratios is deferred until the audit results are reviewed."
 issue = "ml4t/backtest-dev#15"

--- a/validation/generate_parity_claims.py
+++ b/validation/generate_parity_claims.py
@@ -198,6 +198,27 @@ def render_claims(
             f"[real-strategy evidence]({real_strategy_url}) |"
         )
 
+    performance_rows = []
+    for record in real_performance["records"]:
+        target = real_targets[record["framework"]]
+        pinned_framework = f"[{target['display_name']} {target['version']}]({target['source']})"
+        framework_result = record["framework_engine"]
+        ml4t_result = record["ml4t_engine"]
+        framework_ci = framework_result["ci_95_seconds"]
+        ml4t_ci = ml4t_result["ci_95_seconds"]
+        performance_rows.append(
+            f"| {case_labels[record['case_study']]} | {pinned_framework} | "
+            f"{framework_result['median_seconds']:.3f} "
+            f"({framework_ci[0]:.3f}-{framework_ci[1]:.3f}) | "
+            f"{ml4t_result['median_seconds']:.3f} "
+            f"({ml4t_ci[0]:.3f}-{ml4t_ci[1]:.3f}) | "
+            f"{record['framework_to_ml4t_median_ratio']:.3f}x |"
+        )
+
+    timing_policy = real_performance["timing_policy"]
+    environment = real_performance["environment"]
+    excluded = ", ".join(timing_policy["excluded"])
+
     return "\n".join(
         [
             START_MARKER,
@@ -223,10 +244,24 @@ def render_claims(
             "|---|---|---|---|",
             *real_rows,
             "",
-            f"Engine-only timing samples for all {len(real_performance['records'])} passing pairs "
-            "are retained in "
-            f"[real-strategy performance evidence]({real_performance_url}). These measurements "
-            "support only the named strategy, framework version, input bundle, and machine.",
+            "### Real-strategy engine performance",
+            "",
+            f"The table reports engine-call wall time for all {len(performance_rows)} "
+            "correctness-passing pairs. The ratio is framework median / ML4T median; values "
+            "above 1 mean ML4T completed the engine call faster.",
+            "",
+            "| Real strategy | Pinned framework | Framework median (95% CI), s | "
+            "ML4T median (95% CI), s | Framework / ML4T median |",
+            "|---|---|---:|---:|---:|",
+            *performance_rows,
+            "",
+            f"Measured {real_performance['generated_at'][:10]} on "
+            f"`{environment['platform']}` with {environment['cpu_count']} logical CPUs. Each "
+            "side used one isolated warm-up process and ten isolated measured processes. The "
+            f"timer includes only the engine call; it excludes {excluded}. These measurements "
+            "apply only to the named strategy, framework version, frozen input bundle, and "
+            f"machine. Raw samples and bootstrap intervals are retained in "
+            f"[real-strategy performance evidence]({real_performance_url}).",
             "",
             "### Synthetic diagnostic scenarios",
             "",


### PR DESCRIPTION
Publishes engine-only medians, 95% bootstrap intervals, and framework-to-ML4T ratios for all 17 correctness-passing real-strategy pairs. Includes the measurement date, pinned versions, host, process isolation, and timer exclusions. Verification: 2,147 tests passed, strict docs build passed, type checking passed, and all pre-commit hooks passed.