### PR TITLE
fix(release): refresh the newly published package index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Install and exercise the published wheel
         run: |
           uv venv --clear --python 3.12 "$RUNNER_TEMP/published-venv"
-          uv pip install --python "$RUNNER_TEMP/published-venv/bin/python" --index-url https://pypi.org/simple "ml4t-backtest==${{ needs.preflight.outputs.version }}"
+          uv pip install --python "$RUNNER_TEMP/published-venv/bin/python" --index-url https://pypi.org/simple --refresh-package ml4t-backtest "ml4t-backtest==${{ needs.preflight.outputs.version }}"
           "$RUNNER_TEMP/published-venv/bin/python" -I -c "import ml4t.backtest as package; assert package.__version__ == '${{ needs.preflight.outputs.version }}'"
           "$RUNNER_TEMP/published-venv/bin/python" validation/check_documentation_examples.py
 

--- a/tests/contracts/test_release_workflow.py
+++ b/tests/contracts/test_release_workflow.py
@@ -285,6 +285,7 @@ def test_release_reuses_all_ci_gates_and_publishes_the_exact_candidate() -> None
     assert "release_candidate.py verify-index" in post_commands
     assert "gh release download" in post_commands
     assert "ml4t-backtest==${{ needs.preflight.outputs.version }}" in post_commands
+    assert "--refresh-package ml4t-backtest" in post_commands
     recovery = release_jobs["record-recovery"]
     assert "needs.publish.result == 'success'" in recovery["if"]
     recovery_commands = "\n".join(step.get("run", "") for step in recovery["steps"])


### PR DESCRIPTION
## Summary

- force uv to refresh the just-published ml4t-backtest index entry during post-release installation
- prevent a restored pre-publication cache from turning PyPI propagation into a false verification failure
- retain the immutable candidate, digest checks, clean installation, and documentation example gates

## Evidence

- release 0.1.6 attempt 1 published matching artifacts, then failed because uv could not see the version while PyPI JSON already reported its digests
- rerunning only the failed verification job succeeded after propagation
- a local install reproduced the stale-cache failure before the refresh option and succeeded with it
- `uv run pytest tests/contracts/test_release_workflow.py -q --no-cov`: 8 passed
- focused Ruff and pre-commit checks passed

Closes #90