### PR TITLE
release: wait for the simple index before exercising the published wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,20 @@ jobs:
       - name: Install and exercise the published wheel
         run: |
           uv venv --clear --python 3.12 "$RUNNER_TEMP/published-venv"
-          uv pip install --python "$RUNNER_TEMP/published-venv/bin/python" --index-url https://pypi.org/simple --refresh-package ml4t-backtest "ml4t-backtest==${{ needs.preflight.outputs.version }}"
+          # The step above reads https://pypi.org/pypi/<name>/<version>/json; this one reads
+          # https://pypi.org/simple/. The two endpoints propagate independently, so the JSON
+          # API can already serve a version the simple index has not listed yet. On 0.1.7 the
+          # gap was under four minutes and turned a correct publication into a red release run.
+          attempt=1
+          until uv pip install --python "$RUNNER_TEMP/published-venv/bin/python" --index-url https://pypi.org/simple --refresh-package ml4t-backtest "ml4t-backtest==${{ needs.preflight.outputs.version }}"; do
+            if [ "$attempt" -ge 12 ]; then
+              echo "::error::ml4t-backtest==${{ needs.preflight.outputs.version }} is still absent from the simple index after $attempt attempts over 120s."
+              exit 1
+            fi
+            echo "Simple index has not listed ${{ needs.preflight.outputs.version }} yet (attempt $attempt); retrying in 10s."
+            attempt=$((attempt + 1))
+            sleep 10
+          done
           "$RUNNER_TEMP/published-venv/bin/python" -I -c "import ml4t.backtest as package; assert package.__version__ == '${{ needs.preflight.outputs.version }}'"
           "$RUNNER_TEMP/published-venv/bin/python" validation/check_documentation_examples.py
 


### PR DESCRIPTION
The post-release job checks the publication against two different PyPI endpoints and treats them as one. `Verify PyPI identity and digests` reads `https://pypi.org/pypi/<name>/<version>/json`; `Install and exercise the published wheel` reads `https://pypi.org/simple/` through uv. The two propagate independently, so the first can pass on a version the second has not listed yet.

Measured on the 0.1.7 release run: publish completed at 11:59:22Z, the install failed 24 seconds later with `no version of ml4t-backtest==0.1.7`, and a re-run of the same job at 12:03:22Z passed with no change to anything. The package was correctly published throughout; the check was faster than the index.

This retries the install for up to 12 attempts over 120 seconds, the same budget `check_documentation_identity.py` already uses two steps below it, and fails with a message naming the simple index if the version never appears. A genuinely missing artifact still fails the job, two minutes later than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPDj1nioTuD4xATMVyhZxB